### PR TITLE
fix tutorial syntax

### DIFF
--- a/docs/Tutorial_en.md
+++ b/docs/Tutorial_en.md
@@ -188,7 +188,7 @@ To execute the rules, we need to create an instance of `GruleEngine` and with it
 we execute evaluate our `KnowledgeBase` upon the facts in `DataContext`
 
 ```go
-engine = engine.NewGruleEngine()
+engine := engine.NewGruleEngine()
 err = engine.Execute(dataCtx, knowledgeBase, workingMemory)
 if err != nil {
     panic(err)


### PR DESCRIPTION
i was going through the tutorial and notice this small thing in the example:

`engine = engine.NewGruleEngine()` 

should be 

`engine := engine.NewGruleEngine()` 

to make the example copy/past-able.