### PR TITLE
fix/docs : Edited md docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ __"Gopher Holds The Rules"__
 
 # Grule
 
-```
+```go
 import "github.com/hyperjumptech/grule-rule-engine"
 ```
 
 ## Rule Engine for Go
 
-**Grule** is a Rule Engine library for Golang programming language. Inspired by the acclaimed JBOSS Drools, done in a much simple manner.
+**Grule** is a Rule Engine library for the Golang programming language. Inspired by the acclaimed JBOSS Drools, done in a much simple manner.
 
 Like **Drools**, **Grule** have its own *DSL* comparable as follows.
 
 Drools's DRL be like :
 
-```
+```drool
 rule "SpeedUp"
     salience 10
     when
@@ -38,7 +38,7 @@ end
 
 And Grule's GRL be like :
 
-```
+```go
 rule SpeedUp "When testcar is speeding up we keep increase the speed." salience 10  {
     when
         TestCar.SpeedUp == true && TestCar.Speed < TestCar.MaxSpeed
@@ -48,14 +48,13 @@ rule SpeedUp "When testcar is speeding up we keep increase the speed." salience 
 }
 ```
 
-# What is RuleEngine?
----
+# What is RuleEngine
 
-There are no better explanation compared to the article authored by Martin Fowler. You can read the article here ([RulesEngine by Martin Fowler](https://martinfowler.com/bliki/RulesEngine.html)).
+There isn't a better explanation than the article authored by Martin Fowler. You can read the article here ([RulesEngine by Martin Fowler](https://martinfowler.com/bliki/RulesEngine.html)).
 
-Taken from **TutorialsPoint** website (with very slight modification), 
+Taken from **TutorialsPoint** website (with slight modifications),
 
-**Grule** is Rule Engine or a Production Rule System that uses the rule-based approach to implement and Expert System. Expert Systems are knowledge-based systems that use knowledge representation to process acquired knowledge into a knowledge base that can be used for reasoning.
+**Grule** Rule Engine is a Production Rule System that uses the rule-based approach to implement an Expert System. Expert Systems are knowledge-based systems that use knowledge representations to process acquired knowledge into a knowledge base that can be used for reasoning.
 
 A Production Rule System is Turing complete with a focus on knowledge representation to express propositional and first-order logic in a concise, non-ambiguous and declarative manner.
 
@@ -65,13 +64,13 @@ A Production Rule is a two-part structure that uses first-order logic for reason
 
 A Rule Engine allows you to define **“What to Do”** and not **“How to do it.”**
 
-## What is a Rule?
+## What is a Rule
 
 *(also taken from TutorialsPoint)*
 
 Rules are pieces of knowledge often expressed as, "When some conditions occur, then do some tasks."
 
-```
+```go
 When
    <Condition is true>
 Then
@@ -80,7 +79,7 @@ Then
 
 The most important part of a Rule is its when part. If the **when** part is satisfied, the **then** part is triggered.
 
-```
+```go
 rule  <rule_name> <rule_description>
    <attribute> <value> {
    when
@@ -95,7 +94,7 @@ rule  <rule_name> <rule_description>
 
 ### Declarative Programming
 
-Rules make it easy to express solutions to difficult problems and get the solutions verified as well. Unlike codes, Rules are written in less complex language; Business Analysts can easily read and verify a set of rules.
+Rules make it easy to express solutions to difficult problems and get the verifications as well. Unlike codes, Rules are written with less complex language; Business Analysts can easily read and verify a set of rules.
 
 ### Logic and Data Separation
 
@@ -118,11 +117,11 @@ Since business rules are actually treated as data. Adjusting the rule according 
 * [Functions](docs/Function_en.md). List of built-in function and how to to call your own function from GRL.
 * [Grule Events](docs/GruleEvent_en.md). Grule's internal event bus. If you interested to listen to Grule rule events.
 
-# Tasks and Help Wanted.
+# Tasks and Help Wanted
 
-Yes. We need contributor to make Grule even better and useful to Open Source Community.
+Yes. We need contributors to make Grule even better and useful to the Open Source Community.
 
-* Need to do more and more and more test.
+* Need to do more and more and more tests.
 * Better code coverage test.
 * Better commenting for go doc best practice.
 * Improve function argument handling to be more fluid and intuitive.

--- a/docs/FAQ_en.md
+++ b/docs/FAQ_en.md
@@ -8,11 +8,11 @@
 
 **Question** : I got the following panic message when Grule engine is executed.
 
-```
-panic: GruleEngine successfully selected rule candidate for execution after 5000 cycles, this could possibly caused by rule entry(s) that keep added into execution pool but when executed it does not change any data in context. Please evaluate your rule entries "When" and "Then" scope. You can adjust the maximum cycle using GruleEngine.MaxCycle variable.
+```text
+panic: GruleEngine successfully selected rule candidate for execution after 5000 cycles, this could possibly be caused by rule entry(s) that keep added into execution pool but when executed it does not change any data in context. Please evaluate your rule entries "When" and "Then" scope. You can adjust the maximum cycle using GruleEngine.MaxCycle variable.
 ```
 
-**Answer** : The rule engine is done evaluating rule entries for choosing which one to execute in the 5000th time (5000 it the maximum execution cycle). You can change specify any positive number but if you doubt, you an leave it to 5000. When the rule set were evaluated that many times more to this number (the nax cycle) it will panic. To fix this issue, have to understand how rule engine works. The following simulation should help you understand the problem and know how to mitigate it.
+**Answer** : The rule engine is done by evaluating rule entries for choosing which one to execute in the 5000th time (5000 it the maximum execution cycle). You can specify any positive number but if you have ny doubt, you can leave it to 5000. When the rule set is evaluated more times to this number (the max cycle) it will panic. To fix this issue, have to understand how rule engines work. The following simulation should help you understand the problem and know how to mitigate it.
 
 Consider this fact.
 
@@ -23,18 +23,18 @@ type Fact struct {
 }
 ```
 
-The following rules defined.
+Where the following rules are defined:
 
 ```text
 rule GiveCashback "Give cashback if payment is above 100" {
-    When 
+    When
          F.Payment > 100
     Then
          F.Cashback = 10;
 }
 
 rule LogCashback "Emit log if cashback is given" {
-    When 
+    When
          F.Cashback > 5
     Then
          Log("Cashback given :" + F.Cashback);
@@ -59,13 +59,13 @@ Cycle n : Execute "GiveCashback" .... because when F.Payment > 100 is a valid co
 Cycle 5000 : Execute "GiveCashback" .... because when F.Payment > 100 is still a valid condition<br>
 panic
 
-You should notice Grule execute the same rule again and again because the **WHEN** condition keep yielding a valid result.
+You should notice that Grule executes the same rule again and again because the **WHEN** condition keep yielding a valid result.
 
-One way for this solution is to change "GiveCashback" rule to something like :
+One solution for this is to change "GiveCashback" rule to something like :
 
 ```text
 rule GiveCashback "Give cashback if payment is above 100" {
-    When 
+    When
          F.Payment > 100 &&
          F.Cashback == 0
     Then
@@ -73,12 +73,12 @@ rule GiveCashback "Give cashback if payment is above 100" {
 }
 ```
 
-This way, after the 1st execution, the rule's WHEN is become invalid and not get executed again.
+This way, after the 1st execution, the rule's WHEN becomes invalid and not get executed again.
 Or ...
 
 ```text
 rule GiveCashback "Give cashback if payment is above 100" {
-    When 
+    When
          F.Payment > 100
     Then
          F.Cashback = 10;
@@ -96,16 +96,16 @@ in the next cycle. When you execute the engine again, all retracted rules will b
 **Question** : Will there be a feature that enable Grule to load/save rules from database ?
 
 **Answer** : No. While it is a good idea to store your rule entries into a database, Grule will not create any database adapter to automaticaly store and retrieve rule from database.
-You can easily create such adapter your self. Grule have provided a common way to load rules into Knowledgebase from *Reader*, *File*, *Byte Array*, *String* and *Git*. Strings can be easily inserted and selected from database, as you load them into Grule's knowledgebase. 
+You can easily create such adapter yourself. Grule have provided a common way to load rules into Knowledgebase from *Reader*, *File*, *Byte Array*, *String* and *Git*. Strings can be easily inserted and selected from database, as you load them into the Grule's knowledgebase.
 
-There are so many database can potentially store Rule Entries. Creating adapter for those databases means we need to get committed to their driver updates, every single one of them. So we decide that, if you want to store rule in database, you can create such mechanism your self.
+There are too many database that can potentially be used to store Rule Entries. Creating adapters for those databases means we need to get committed to their driver updates, every single one of them. So we have decided that, if you want to store rule in a database, you can create such mechanism yourself.
 
 ---
 
 ## 3. Maximum number of rule in one knowledge-base
 
-**Question** : How many rule entry can be inserted into knowledgebase ?
+**Question** : How many rule entry can be inserted into the knowledgebase?
 
-**Answer** : You can have as many rule entries you want. But there should be at least one minimum.
+**Answer** : You can have as many rule entries as you want, but there should be at least one as a minimum.
 
 ---

--- a/docs/Function_en.md
+++ b/docs/Function_en.md
@@ -2,16 +2,15 @@
 
 [Tutorial](Tutorial_en.md) | [Rule Engine](RuleEngine_en.md) | [GRL](GRL_en.md) | [RETE Algorithm](RETE_en.md) | [Functions](Function_en.md) | [Grule Events](GruleEvent_en.md) | [FAQ](FAQ_en.md)
 
+## Built-In Functions
 
-## Build-In Functions
+Built-in functions are all defined within the `ast/BuildInFunctions.go` file. As of now, they are :
 
-All build-in function are all defined within the `ast/BuildInFunctions.go` File. As of now, they are :
-
-### MakeTime(year, month, day, hour, minute, second int64) time.Time 
+### MakeTime(year, month, day, hour, minute, second int64) time.Time
 
 `MakeTime` will create a `time.Time` with local `locale`.
 
-#### Arguments:
+#### Arguments
 
 * `year` is the Year number.
 * `month` is the Month number, January = 1.
@@ -28,18 +27,18 @@ All build-in function are all defined within the `ast/BuildInFunctions.go` File.
 
 ```text
 rule SetExpire "Set the expire date for Fact created before 2020" {
-    when 
+    when
        Fact.CreateTime < MakeTime(2020,1,1,0,0,0)
     then
        Fact.ExpireTime = MakeTime(2021,1,1,0,0,0);
 }
-``` 
+```
 
 ### Changed(variableName string)
 
-`Changed` will make sure the specified variable name is removed from working memory.
+`Changed` will make sure the specified variableName is removed from the working memory.
 
-#### Arguments:
+#### Arguments
 
 * `variableName` the variable name to be removed from working memory.
 
@@ -80,7 +79,7 @@ rule ResetTime "Reset the lastUpdate time" {
 
 #### Arguments
 
-* `text` The text to emit into Log-Debug
+* `text` The text to emit into the Log-Debug
 
 #### Example
 
@@ -89,7 +88,7 @@ rule SomeRule "Log candidate name if he is bellow 17 years old" {
     when
         Candidate.Age < 17
     then
-        Log("Under aged : " + Candidate.Name); 
+        Log("Under aged : " + Candidate.Name);
 }
 ```
 
@@ -121,7 +120,7 @@ rule CheckEducation "Check candidate's education fact" {
 ### IsZero(i interface{}) bool
 
 `IsZero` will check any variable in the argument for its `Zero` status value. Zero means
-that the variable is newly defined and have not assigned with any value.
+that the variable is newly defined and have not been assigned with any value.
 This is usually applied to types like `string`, `int64`, `uint64`, `bool`, `time.Time`, etc. 
 
 #### Arguments
@@ -147,8 +146,8 @@ rule CheckStartTime "Check device's starting time." {
 ### Retract(ruleName string)
 
 `Retract` will retract the specified rule from next cycle evaluation. If a rule
-is retracted, it's `when` scope will not be evaluated. When the rule engine execute
-again, all retract status of all rules will be restored.
+is retracted, its `when` scope will not be evaluated. When the rule engine execute
+again, all the retracted status of all rules will be restored.
 
 #### Arguments
 
@@ -183,7 +182,7 @@ rule CheckStartTime "Check device's starting time." salience 1000 {
 ```text
 rule StartNewYearProcess "Check if its a new year to restart new FinancialYear." salience 1000 {
     when
-        GetTimeYear(Now()) != GL.FinancialYear         
+        GetTimeYear(Now()) != GL.FinancialYear
     then
         GL.CloseYear(GL.FinancialYear)
 }
@@ -206,7 +205,7 @@ rule StartNewYearProcess "Check if its a new year to restart new FinancialYear."
 ```text
 rule StartNewYearProcess "Check if its a new year to restart new FinancialYear." salience 1000 {
     when
-        isZero(Process.Month)        
+        isZero(Process.Month)
     then
         Process.Month = GetTimeMonth(Process.Month);
 }
@@ -214,7 +213,7 @@ rule StartNewYearProcess "Check if its a new year to restart new FinancialYear."
 
 ### GetTimeDay(time time.Time) int
 
-`GetTimeDay` will extract the Day of Month value of the time argument.
+`GetTimeDay` will extract the Day of the month value of the time argument.
 
 #### Arguments
 
@@ -222,14 +221,14 @@ rule StartNewYearProcess "Check if its a new year to restart new FinancialYear."
 
 #### Returns
 
-* Day of month value of the time. 
+* Day of month value of the time.
 
 #### Example
 
 ```text
 rule GreetEveryDay "Log a greeting every day." salience 1000 {
     when
-        Greeting.Day != GetTimeDay(Now())     
+        Greeting.Day != GetTimeDay(Now())
     then
         Log("Its a new Day !!!")
         Retract("GreetEveryDay")
@@ -237,7 +236,6 @@ rule GreetEveryDay "Log a greeting every day." salience 1000 {
 ```
 
 ### GetTimeHour(time time.Time) int
-
 
 `GetTimeHour` will extract the Hour value of the time argument.
 
@@ -247,14 +245,14 @@ rule GreetEveryDay "Log a greeting every day." salience 1000 {
 
 #### Returns
 
-* Hour value of the time. Is between 0 to 23 
+* Hour value of the time. Is between 0 to 23
 
 #### Example
 
 ```text
 rule DailyCheckBuild "Execute build every 6AM and 6PM." {
     when
-        GetTimeHour(Now()) == 6 || GetTimeHour(Now()) == 18 
+        GetTimeHour(Now()) == 6 || GetTimeHour(Now()) == 18
     then
         CiCd.BuildDaily();
         Retract("DailyCheckBuild");
@@ -262,7 +260,6 @@ rule DailyCheckBuild "Execute build every 6AM and 6PM." {
 ```
 
 ### GetTimeMinute(time time.Time) int
-
 
 `GetTimeMinute` will extract the Minute value of the time argument.
 
@@ -272,7 +269,7 @@ rule DailyCheckBuild "Execute build every 6AM and 6PM." {
 
 #### Returns
 
-* Minute value of the time. Is between 0 to 59 
+* Minute value of the time, between 0 to 59
 
 #### Example
 
@@ -280,7 +277,7 @@ rule DailyCheckBuild "Execute build every 6AM and 6PM." {
 rule DailyCheckBuild "Execute build every 6.30AM and 6.30PM." {
     when
         (GetTimeHour(Now()) == 6 || GetTimeHour(Now()) == 18) &&
-        GetTimeMinute(Now()) == 30 
+        GetTimeMinute(Now()) == 30
     then
         CiCd.BuildDaily();
         Retract("DailyCheckBuild");
@@ -297,7 +294,7 @@ rule DailyCheckBuild "Execute build every 6.30AM and 6.30PM." {
 
 #### Returns
 
-* Second value of the time. Is between 0 to 59 
+* Second value of the time, between 0 to 59
 
 #### Example
 
@@ -305,7 +302,7 @@ rule DailyCheckBuild "Execute build every 6.30AM and 6.30PM." {
 rule DailyCheckBuild "Execute build every 6.30AM and 6.30PM." {
     when
         (GetTimeHour(Now()) == 6 || GetTimeHour(Now()) == 18) &&
-        GetTimeMinute(Now()) == 30 && GetTimeSecond(Now()) == 0 
+        GetTimeMinute(Now()) == 30 && GetTimeSecond(Now()) == 0
     then
         CiCd.BuildDaily();
         Retract("DailyCheckBuild");
@@ -313,7 +310,6 @@ rule DailyCheckBuild "Execute build every 6.30AM and 6.30PM." {
 ```
 
 ### IsTimeBefore(time, before time.Time) bool
-
 
 `IsTimeBefore` will check if a time value is before the other time value.
 
@@ -341,7 +337,6 @@ rule PromotionExpireCheck  "Apply a promotion if the promotion's expired date is
 
 ### IsTimeAfter(time, after time.Time) bool
 
-
 `IsTimeAfter` will check if a time value is after the other time value.
 
 #### Arguments
@@ -367,8 +362,7 @@ rule AdditionalTax  "Apply additional tax if purchase after date specified." {
 
 ### TimeFormat(time time.Time, layout string) string
 
-
-`TimeFormat` will check if a time value is after the other time value.
+`TimeFormat` will format a time argument to a format specified by `layout` argument.
 
 #### Arguments
 
@@ -394,8 +388,8 @@ rule LogPurchaseDate  "Log the purchase date." {
 
 ## Custom Functions
 
-All invocable functions which are invocable from the DataContext is **Invocable** from within the rule,
-both in the "When" scope and "Then" scope.
+All functions which are invocable from the DataContext is **Invocable** from within the rule,
+both in the "When" scope and the "Then" scope.
 
 Thus, you can create functions and have your Fact as receiver, and those function can be called from GRL.
 
@@ -414,7 +408,7 @@ func (p *MyPoGo) AppendString(aString, subString string) string {
 }
 ```
 
-And add the struct into knowledge base 
+And add the struct into knowledge base
 
 ```go
 dctx := grule.context.NewDataContext()
@@ -432,8 +426,8 @@ then
 
 ### Important Thing you must know about Custom Function in Grule
 
-When you make your own function to be called from rule engine, you need to know the following rules.
+When you make your own function to be called from the rule engine, you need to know the following rules.
 
-1. The function must be visible. Public function convention should start with capital letter. Private functions cant be executed.
-2. The function must only return 1 type. Returning multiple variable from function are not acceptable, the rule execution will fail if there are multiple return variable.
-3. The way number literal were treated in Grule's DRL is; **decimal** will always taken as `int64` and **real** as `float64`, thus always consider to define your function argument and returns between `int64` and `float64` when your function works with numbers.
+1. The function must be visible. The convention for public functions should start with a capital letter. Private functions cannot be executed.
+2. The function must only return 1 type. Returning multiple variables from a function is not supported, the rule execution will fail if there are multiple return variables.
+3. The way number literals are treated in Grule's DRL is such that a **decimal** will always be taken as an `int64` type and a **real** as `float64`, thus always consider to define your function arguments and returns from the types `int64` and `float64` when you work with numbers.

--- a/docs/GRL_en.md
+++ b/docs/GRL_en.md
@@ -2,8 +2,8 @@
 
 [Tutorial](Tutorial_en.md) | [Rule Engine](RuleEngine_en.md) | [GRL](GRL_en.md) | [RETE Algorithm](RETE_en.md) | [Functions](Function_en.md) | [Grule Events](GruleEvent_en.md) | [FAQ](FAQ_en.md)
 
-The **GRL**  is a DSL (Domain Specific Language) designed for Grule. Its a simplified language
-to be used for defining rule evaluation criteria and action to be executed if the criteria were met.
+The **GRL** is a DSL (Domain Specific Language) designed for Grule. It's a simplified language
+to be used for defining rule evaluation criterias and actions to be executed if the criteria(s) are met.
 
 Generally, the language have the following structure :
 
@@ -16,26 +16,24 @@ rule <RuleName> <RuleDescription> [salience <priority>] {
 }
 ```
 
-**RuleName** identify a specific rule. The name should be unique in the entire knowledge base, consist of one word thus 
-it should not contains white-space. 
+**RuleName** identifies a specific rule. The name should be unique in the entire knowledge base, consist of one word and
+it should not contains a white-space.
 
 **RuleDescription** describes the rule. The description should be enclosed with a double-quote.
 
-**Salience** defines the importance of the rule. Its an optional rule configuration, and by default, when you don't specify them, all rule have the salience of 0 (zero).
-The lower the value, the less important the rule. Whenever multiple rule are a candidate for execution, highest salience rule will be executed first. You
-may define negative value for the salience, to make the salience even lower. Like any implementation of Rule-Engine,
-there are no definitive algorithm to specify which rule to be execute in case of conflicting candidate, the engine may run which ever they like.
-Salience is one way of hinting the rule engine of which rule have more importance compared to the other.
+**Salience** defines the importance of the rule. It's an optional rule configuration, and by default, when you don't specify them, all rules will have the salience value of 0 (zero).
+The lower the value, the less important the rule. Whenever multiple rules become a candidate for execution, the highest salience rule will be executed first. You may define negative values for the salience to make the salience even lower. Like any implementation of Rule-Engine, there are no definitive algorithm to specify which rule to be execute in case of conflicting candidate, the engine may run which ever they like.
+Salience is one way of hinting to the rule engine which rules have more importance relatively.
 
-**Boolean Expression** is an expression that will be used by rule engine to identify if that specific rule
-are a candidate for execution for the current facts.
+**Boolean Expression** is an expression that will be evaluated by the rule engine to identify if that specific rule
+is a candidate for execution with the current facts.
 
-**Assignment or Operation Expression** contains list of expressions (each expression should be ended with ";" symbol.) 
+**Assignment or Operation Expression** contains list of expressions (each expression should be ended with ";" character).
 The expression are designed to modify the current fact values, making calculation, make some logging, etc.
 
-#### Boolean Expression 
+#### Boolean Expression
 
-Boolean expression comes natural for java or golang developer in GRL. 
+Boolean expression comes naturally for java or golang developer in GRL.
 
 ```go
 when
@@ -44,6 +42,7 @@ when
 then
      ...
 ```
+
 #### Constants and Literals
 
 | Literal | Description                                                            | Example                          |
@@ -60,7 +59,7 @@ Operators supported :
 * Logical operators : `&&` and `||`
 * Comparison operators : `<`,`<=`,`>`,`>=`,`==`,`!=` 
 
-Operator precedence : 
+Operator precedence :
 
 Grule follows operator precedence in Golang.
 
@@ -95,7 +94,7 @@ rule SpeedUp "When testcar is speeding up we keep increase the speed."  {
         TestCar.SpeedUp == true && TestCar.Speed < TestCar.MaxSpeed
     then
         TestCar.Speed = TestCar.Speed + TestCar.SpeedIncrement;
-		DistanceRecord.TotalDistance = DistanceRecord.TotalDistance + TestCar.Speed;
+            DistanceRecord.TotalDistance = DistanceRecord.TotalDistance + TestCar.Speed;
 }
 
 rule StartSpeedDown "When testcar is speeding up and over max speed we change to speed down."  {
@@ -103,7 +102,7 @@ rule StartSpeedDown "When testcar is speeding up and over max speed we change to
         TestCar.SpeedUp == true && TestCar.Speed >= TestCar.MaxSpeed
     then
         TestCar.SpeedUp = false;
-		log("Now we slow down");
+            log("Now we slow down");
 }
 
 rule SlowDown "When testcar is slowing down we keep decreasing the speed."  {
@@ -111,15 +110,15 @@ rule SlowDown "When testcar is slowing down we keep decreasing the speed."  {
         TestCar.SpeedUp == false && TestCar.Speed > 0
     then
         TestCar.Speed = TestCar.Speed - TestCar.SpeedIncrement;
-		DistanceRecord.TotalDistance = DistanceRecord.TotalDistance + TestCar.Speed;
+        DistanceRecord.TotalDistance = DistanceRecord.TotalDistance + TestCar.Speed;
 }
 
 rule SetTime "When Distance Recorder time not set, set it." {
-	when
-		isNil(DistanceRecord.TestTime)
-	then
-		log("Set the test time");
-		DistanceRecord.TestTime = now();
+    when
+        isNil(DistanceRecord.TestTime)
+    then
+        log("Set the test time");
+        DistanceRecord.TestTime = now();
 }
 ```
 

--- a/docs/GruleEvent_en.md
+++ b/docs/GruleEvent_en.md
@@ -2,12 +2,12 @@
 
 [Tutorial](Tutorial_en.md) | [Rule Engine](RuleEngine_en.md) | [GRL](GRL_en.md) | [RETE Algorithm](RETE_en.md) | [Functions](Function_en.md) | [Grule Events](GruleEvent_en.md) | [FAQ](FAQ_en.md)
 
-Sometime you want to know what happening when Rule engine is running. 
+Sometimes you may want to know what is happening when the Rule engine is running.
 You may want to know when a certain rule is being executed, when the engine
 is started, or ended, or to simply know what is the current execution cycle.
 
 Grule is running an internal *EventBus* in it. All you have to do is to obtain
-a *Subscriber* to its *Broker* by specifying function to capture the event.
+a *Subscriber* to its *Broker* by specifying a function to capture the event.
 
 ```go
 
@@ -20,35 +20,35 @@ import (
 ...
 
 
-	ruleEntrySubscriber := eventbus.DefaultBrooker.GetSubscriber(events.RuleEntryEventTopic, func(i interface{}) error {
-		if i != nil && getTypeOf(i) == "*RuleEntryEvent" {
-			event := i.(*events.RuleEntryEvent)
-			if event.EventType == events.RuleEntryExecuteStartEvent {
-				log.Infof("Rule executed %s", event.RuleName)
-			}
-		} else if i != nil {
-			log.Infof("RuleEntry Subscriber, Receive type is %s ", getTypeOf(i))
-		}
-		return nil
-	})
-	ruleEntrySubscriber.Subscribe()
+    ruleEntrySubscriber := eventbus.DefaultBrooker.GetSubscriber(events.RuleEntryEventTopic, func(i interface{}) error {
+    if i != nil && getTypeOf(i) == "*RuleEntryEvent" {
+            event := i.(*events.RuleEntryEvent)
+            if event.EventType == events.RuleEntryExecuteStartEvent {
+                log.Infof("Rule executed %s", event.RuleName)
+            }
+        } else if i != nil {
+            log.Infof("RuleEntry Subscriber, Receive type is %s ", getTypeOf(i))
+        }
+        return nil
+    })
+    ruleEntrySubscriber.Subscribe()
 ```
 
 Another example
 
 ```go
-	ruleEngineSubscriber := eventbus.DefaultBrooker.GetSubscriber(events.RuleEngineEventTopic, func(i interface{}) error {
-		if i != nil && getTypeOf(i) == "*RuleEngineEvent" {
-			event := i.(*events.RuleEngineEvent)
-			if event.EventType == events.RuleEngineEndEvent {
-				log.Infof("Engine finished in %d cycles", event.Cycle)
-			}
-		} else if i != nil {
-			log.Infof("RuleEngine Subscriber, Receive type is %s ", getTypeOf(i))
-		}
-		return nil
-	})
-	ruleEngineSubscriber.Subscribe()
+    ruleEngineSubscriber := eventbus.DefaultBrooker.GetSubscriber(events.RuleEngineEventTopic, func(i interface{}) error {
+        if i != nil && getTypeOf(i) == "*RuleEngineEvent" {
+            event := i.(*events.RuleEngineEvent)
+            if event.EventType == events.RuleEngineEndEvent {
+                log.Infof("Engine finished in %d cycles", event.Cycle)
+            }
+        } else if i != nil {
+            log.Infof("RuleEngine Subscriber, Receive type is %s ", getTypeOf(i))
+        }
+        return nil
+    })
+    ruleEngineSubscriber.Subscribe()
 ```
 
 Like a common *Messaging* infrastructure, bule is publishing *messages* on a certain topic.
@@ -59,13 +59,13 @@ Those topic are:
 package events
 ...
 const (
-	// RuleEntryEventTopic the event topic for rule entry
-	RuleEntryEventTopic = "RuleEntryEvent"
+    // RuleEntryEventTopic the event topic for rule entry
+    RuleEntryEventTopic = "RuleEntryEvent"
 
-	// RuleEngineEventTopic an event topic for rule engine
-	RuleEngineEventTopic = "RuleEngineEvent"
+    // RuleEngineEventTopic an event topic for rule engine
+    RuleEngineEventTopic = "RuleEngineEvent"
 )
-``` 
+```
 
 The following are the struct get sents...
 
@@ -75,26 +75,26 @@ package events
 
 // RuleEntryEvent is an event data to be sent for RuleEntryEvent topic
 type RuleEntryEvent struct {
-	fmt.Stringer
+    fmt.Stringer
 
-	// Name of the rule entry involved in this event.
-	RuleName string
+    // Name of the rule entry involved in this event.
+    RuleName string
 
-	//The event type to further categorized what is actually happening
-	EventType int
+    //The event type to further categorized what is actually happening
+    EventType int
 }
 
 // RuleEngineEvent is an event data to be sent for RuleEngineEvent topic
 type RuleEngineEvent struct {
-	fmt.Stringer
-	//The event type to further categorized what is actually happening
-	EventType int
+    fmt.Stringer
+    //The event type to further categorized what is actually happening
+    EventType int
 
-	// The current execution cycle when this event is emitted
-	Cycle uint64
+    // The current execution cycle when this event is emitted
+    Cycle uint64
 
-	// An error, if this event is emitted because of an error
-	Error error
+    // An error, if this event is emitted because of an error
+    Error error
 }
 ```
 
@@ -104,34 +104,34 @@ The following is list of `EventType` that explains further about the event.
 package events
 ...
 const (
-	// RuleEntryAddedEvent an event when Rule Entry get added into knowledge base
-	RuleEntryAddedEvent int = iota
+    // RuleEntryAddedEvent an event when Rule Entry get added into knowledge base
+    RuleEntryAddedEvent int = iota
 
-	// RuleEntryRemovedEvent an event when Rule Entry get removed from knowledge base
-	RuleEntryRemovedEvent
+    // RuleEntryRemovedEvent an event when Rule Entry get removed from knowledge base
+    RuleEntryRemovedEvent
 
-	// RuleEntryRetractedEvent an event when Rule Entry get retracted from rule engine next cycle execution
-	RuleEntryRetractedEvent
+    // RuleEntryRetractedEvent an event when Rule Entry get retracted from rule engine next cycle execution
+    RuleEntryRetractedEvent
 
-	// RuleEntryResetEvent an event when Rule Entry get restored to next rule engine cycle execution
-	RuleEntryResetEvent
+    // RuleEntryResetEvent an event when Rule Entry get restored to next rule engine cycle execution
+    RuleEntryResetEvent
 
-	// RuleEntryExecuteStartEvent an event when Rule Entry about to be executed
-	RuleEntryExecuteStartEvent
+    // RuleEntryExecuteStartEvent an event when Rule Entry about to be executed
+    RuleEntryExecuteStartEvent
 
-	// RuleEntryExecuteEndEvent an event when Rule Entry finish execution
-	RuleEntryExecuteEndEvent
+    // RuleEntryExecuteEndEvent an event when Rule Entry finish execution
+    RuleEntryExecuteEndEvent
 
-	// RuleEngineStartEvent an event when Rule Engine is about to start
-	RuleEngineStartEvent
+    // RuleEngineStartEvent an event when Rule Engine is about to start
+    RuleEngineStartEvent
 
-	// RuleEngineEndEvent an event when Rule Engine is just finished
-	RuleEngineEndEvent
+    // RuleEngineEndEvent an event when Rule Engine is just finished
+    RuleEngineEndEvent
 
-	// RuleEngineCycleEvent an event when Rule Engine start a cycle
-	RuleEngineCycleEvent
+    // RuleEngineCycleEvent an event when Rule Engine start a cycle
+    RuleEngineCycleEvent
 
-	// RuleEngineErrorEvent an event when Rule Engine encounter an error in it's execution
-	RuleEngineErrorEvent
+    // RuleEngineErrorEvent an event when Rule Engine encounter an error in it's execution
+    RuleEngineErrorEvent
 )
 ```

--- a/docs/RETE_en.md
+++ b/docs/RETE_en.md
@@ -4,11 +4,11 @@
 
 From Wikipedia : The Rete algorithm (/ˈriːtiː/ REE-tee, /ˈreɪtiː/ RAY-tee, rarely /ˈriːt/ REET, /rɛˈteɪ/ reh-TAY) is a pattern matching algorithm for implementing rule-based systems. The algorithm was developed to efficiently apply many rules or patterns to many objects, or facts, in a knowledge base. It is used to determine which of the system's rules should fire based on its data store, its facts.
 
-Some form of RETE algorithm were employed in `grule-rule-engine` starting from version `1.1.0`.
+Some form of the RETE algorithm was implemented in `grule-rule-engine` starting from version `1.1.0`.
 It replaces the __Naive__ approach when evaluating rules to add to `ConflictSet`.
- 
-`ExpressionAtom` in the DRL were compiled and will not be duplicated within the working memory of the engine.
-This makes the engine performance be increased significantly if you have many rules defined with lots of duplicated expressions
+
+`ExpressionAtom` in the DRL are compiled and will not be duplicated within the working memory of the engine.
+This increased the engine performance significantly if you have many rules defined with lots of duplicated expressions
 or lots of heavy function/method calls.
 
 Grule's RETE implementation don't have `Class` selector as one expression may involve multiple class. For example an expression such as:
@@ -55,20 +55,20 @@ And we have DRL like ...
 
 ```go
 rule ... {
-    when 
+    when
         Fact.VeryHeavyAndLongFunction() && Fact.StringValue == "Fish"
     then
         ...
 }
 rule ... {
-    when 
+    when
         Fact.VeryHeavyAndLongFunction() && Fact.StringValue == "Bird"
     then
         ...
 }
 rule ... {
-    when 
-        Fact.VeryHeavyAndLongFunction() && Fact.StringValue == "Mamal"
+    when
+        Fact.VeryHeavyAndLongFunction() && Fact.StringValue == "Mammal"
     then
         ...
 }
@@ -76,18 +76,18 @@ rule ... {
 // and alot more of simillar rule
 ...
 rule ... {
-    when 
+    when
         Fact.VeryHeavyAndLongFunction() && Fact.StringValue == "Insect"
     then
         ...
 }
 ```
 
-Executing the DRL above might "kill" the engine because when it try to choose what rule to execute,
-the engine will call the `Fact.VeryHeavyAndLongFunction` function in every rules `when` scope. 
+Executing the DRL above might "kill" the engine because when it tries to choose what rules to execute,
+the engine will call the `Fact.VeryHeavyAndLongFunction` function in every rule's `when` scope.
 
-Thus, instead of executing the `Fact.VeryHeavyAndLongFunction` while evaluating each 
-rule, Rete algorithm only evaluate them once (one the first encounter with the function), and remember the result 
+Thus, instead of executing the `Fact.VeryHeavyAndLongFunction` while evaluating each
+rule, Rete algorithm only evaluate them once (one the first encounter with the function), and remember the result
 for the rest of the rules.
 
 The same with `Fact.StringValue`. Rete algorithm will load the value from the object instance and
@@ -95,7 +95,7 @@ remember it. Until it got changed in the `then` scope, as in ...
 
 ```go
 rule ... {
-    when 
+    when
         ...
     then
         Fact.StringValue = "something else";
@@ -104,12 +104,12 @@ rule ... {
 
 ### What is inside Grule's Working-Memory
 
-Grule will try to remember all of the `Expression` defined within rule's `when` scope of all rules 
-in the KnowledgeBase. 
+Grule will try to remember all of the `Expression` defined within rule's `when` scope of all rules
+in the KnowledgeBase.
 
-First, It will try its best to make sure none of the `v` AST (Abstract Syntax Tree) node get duplicated
+First, It will try its best to make sure none of the `v` AST (Abstract Syntax Tree) node get duplicated.
 
-Second, Each of this AST node can only be evaluated once, until it's relevant `variable` get changed. For example :
+Second, each of this AST node can only be evaluated once, until it's relevant `variable` get changed. For example :
 
 Boolean Expression :
 
@@ -127,7 +127,7 @@ Expression "Fact.C" --> A variable
 Expression "Fact.Func(Fact.C)"" --> A function containing argument Fact.C
 Expression "20" --> A constant
 Expression "Fact.B + Fact.Func(Fact.C)" --> A math operation contains 2 variable; Fact.B and Fact.C
-Expression "(Fact.B + Fact.Func(Fact.C))" - 20 -- A math operation also contains 2 variable. 
+Expression "(Fact.B + Fact.Func(Fact.C))" - 20 -- A math operation also contains 2 variable.
 ```
 
 Each of the above Expressions will be remembered for their underlaying values whenever
@@ -155,7 +155,7 @@ This makes those Expression removed from the working memory and get re-evaluated
 ### Known RETE issue with Functions or Methods
 
 While Grule will try to remember any variable it evaluate within the `when` and `then` scope, if you change
-the variable value from outside the rule engine, for example changed from within a function call, 
+the variable value from outside the rule engine, for example changed from within a function call,
 Grule won't be able to see this change, thus Grule may mistakenly evaluate a variable which already changed.
 
 Consider the following fact:
@@ -184,9 +184,9 @@ In your GRL you did something like this
 
 ```go
 rule one "One" {
-    when 
-        Fact.StringValue == "One" 
-        // here grule remember that Fact.StringValue value is "One"
+    when
+        Fact.StringValue == "One"
+        // here grule remembers that Fact.StringValue value is "One"
     then
         Fact.SetStringValue("Two");
         // here grule does not know if Fact.StringValue has changed inside the function.
@@ -194,7 +194,7 @@ rule one "One" {
 }
 
 rule two "Two" {
-    when 
+    when
         Fact.StringValue == "Two"
         // Because of that, this will never evaluated true.
     then
@@ -202,7 +202,7 @@ rule two "Two" {
 }
 ```
 
-Thus the engine will finish without error, but the expected result, where `Fact.StringValue` should be `Three`
+Thus the engine will finish without error, but the expected result, where `Fact.StringValue` should be `Two`
 is not met.
 
 To overcome this, you should tell grule if the variable has changed using `Changed` function.
@@ -210,7 +210,7 @@ To overcome this, you should tell grule if the variable has changed using `Chang
 ```go
 rule one "One" {
     when 
-        Fact.StringValue == "One" 
+        Fact.StringValue == "One"
         // here grule remember that Fact.StringValue value is "One"
     then
         Fact.SetStringValue("Two");
@@ -221,4 +221,3 @@ rule one "One" {
         Changed("Fact.StringValue")
 }
 ```
-

--- a/docs/RuleEngine_en.md
+++ b/docs/RuleEngine_en.md
@@ -2,21 +2,21 @@
 
 [Tutorial](Tutorial_en.md) | [Rule Engine](RuleEngine_en.md) | [GRL](GRL_en.md) | [RETE Algorithm](RETE_en.md) | [Functions](Function_en.md) | [Grule Events](GruleEvent_en.md) | [FAQ](FAQ_en.md)
 
-Rule engine, as Martin Fowler explained, is another alternative of computational model.
+Rule engine, as Martin Fowler explained, is an alternative to the computational model.
 Where you evaluate multiple conditions, by which you then select an appropriate action if a certain
 condition are met. In the simplest explanation, each *Rule* depicts an *if-then* statement.
 
-You feed a collection of rules into a **KnowledgeBase**, then the *engine* use each of the 
-rule inside the KnowledgeBase to evaluate some **Facts**. If a rule's requirement were met,
+You feed a collection of rules into a **KnowledgeBase**, then the *engine* use each of the
+rule inside the KnowledgeBase to evaluate some **Facts**. If a rule's requirements are met,
 the **action** specified by that selected rule will be executed.
 
 ## Fact
 
-A fact is a fact, silly it may sound but that's what it is. Fact, in rule engine context
-is basically an information to be evaluated. Fact can be coming from many source, eg. 
+A fact is a fact, as silly it may sound but that's what it is. Fact, in rule engine context
+is basically a piece of information that can be evaluated. Fact can be from any source, eg.
 Database, triggered process, point of sales, reports, etc.
- 
-If you still don't get it, it would be much easier to just look
+
+If you still can't picture it, it would be much easier to just look
 into an example or fact. Suppose we have a fact
 
 ```text
@@ -29,11 +29,11 @@ Purchase Transaction
     Tax           : ?
     Discount      : ?
     Final Price   : ?
-```   
+```
 
 As you can see, a **Fact** is basically any information or data about something.
 
-From this sample Purchasing fact, we know lots of information, The item being purchased, the quantity,
+From this sample Purchasing fact, we know lots of information, the item being purchased, the quantity,
 purchase date, etc. However, we don't know how much tax should be given to that purchase,
 how much discount we can give, and the final price the buyer should pay.
 
@@ -41,13 +41,13 @@ how much discount we can give, and the final price the buyer should pay.
 
 A rule is a some definition of specification/condition to evaluate a **Fact**. If the
 rule's specification are met by the Fact, the rule's action will be selected to be executed.
-Some time, multiple rule are selected because it's specification all met for the Fact, then we know
-that there's a conflict. All rules in conflict are called **Conflict Set**. To resolve this
+Sometimes, multiple rules are selected because their specifications all meet the Fact, then we know
+that there's a conflict. All rules in a conflict are called **Conflict Set**. To resolve this
 conflict, we should specify some *strategy* that we will cover later.  
 
 Back to our example, as in a simple *purchasing* system, some business rule should be established in order to
-calculate final price. Like calculating the tax first and then discount. With both tax and discount
-are known, then we can tell the price.
+calculate the final price. Like calculating the tax first and then the discount. With both tax and discount
+are known, then we can show the price.
 
 Now lets specify some rules.
 
@@ -101,30 +101,30 @@ Rule 7
    - the Item's Tax is known AND
    - the Item's Final Price is not known
    THEN
-   - Item's Final Price is calculate price from Total Price 
-     with given Tax and Discount 
+   - Item's Final Price is calculate price from Total Price
+     with given Tax and Discount
 ```
 
 If you examine the above rules, you should easily understand the meaning
-of **rule**. This collection of rule will form a **Knowledge**. A knowledge of
+of **rule**. These collection of rules will form a **Knowledge**. A knowledge of
 **"How to calculate Item's final price"**.
 
 ## Cycle
 
-A rule evaluation cycle will start with evaluating each of the rule's requirement (the **IFs**)
-to select which rule potentially executed. Everytime the engine found satisfied 
-requirement, instead of execute the satisfied rule's action (the **THENs**), it add 
-that rule into list rule candidate (Conflict Set). 
+A rule evaluation cycle will start with evaluating each of the rule's requirements (the **IFs**)
+to select which rule to potentially execute. Everytime the engine finds a satisfied
+requirement, instead of executing the satisfied rule's action (the **THENs**), it adds
+that rule into a list of rule candidate (Conflict Set).
 
-When all rule's requirement have been evaluated, 
-the engine will execute the selected rule's action ? Well, if theres only 1 rule
+When all rules' requirement have been evaluated,
+the engine will execute the selected rule's action? Well, if theres only 1 rule
 inside the Conflict Set, Yes. If there's no Rule inside, that means the Engine execution
-is finished. If there are multiple rule, the engine need to apply some strategy 
-to select one rule and execute it's action.
+is finished. If there are multiple rules, the engine need to apply some strategy
+to select one rule and execute its action.
 
-If an action get executed, the cycle repeats again as long as there's an action executed.
-When no more action get executed, this means that there are no more rule were statisfied
-by the fact, the cycle stops and the rule engine finished.
+If an action get executed, the cycle repeats again as long as there's an action that need execution.
+When no more action gets executed, this means that there are no more rule that are statisfied
+by the fact, the cycle stops and the rule engine is finished.
 
 The *Pseudo Code* for this depicted bellow
 
@@ -138,7 +138,7 @@ BEGIN
             End If
         End Check
     End For
-    If CONFLICT SET is EMPTY 
+    If CONFLICT SET is EMPTY
         Finished
         END
     If CONFLICT SET has 1 RULE
@@ -151,22 +151,22 @@ BEGIN
         Clear CONFLICT SET
         Repeat cycle from BEGIN
 END
-``` 
+```
 
-Grule will keep track of how many cycle its been repeating. If the rule evaluation and executen
-been repeated too many time, above a speciffic amount of cycle, the engine will terminate
+Grule will keep track of how many cycles it has been repeating. If the rule evaluation and execution have
+been repeated too many times, above a speciffic amount of cycles, the engine will terminate
 and an error will be emitted.
 
 ## Conflict Set Resolution Strategy
 
-As explained above, The rule engine will evaluate all rule's requirement and add 
-them into a list of conflicting rule called **Conflict Set**, If only 1 rule
-inside the list, it means that no other rule(s) conflicting that 1 rule. The engine
+As explained above, The rule engine will evaluate all rules' requirements and add
+them into a list of conflicting rule called the**Conflict Set**. If only 1 rule is
+inside the list, it means that are no rule(s) conflicting with that 1 rule. The engine
 will immediately execute the rule's action.
 
-If there are many rules, there's clearly a conflict. There are many conflict resolution strategy
-can be implemented. The easiest way to do is, by specifying rule's **salience** (also known as
-**priority** or **importance**. We add some indication into the rule definition like...
+If there are multiple rules, there maybe conflicts. There are many conflict resolution strategies that
+can be implemented. The easiest way to do it is by specifying the rule's **salience** (also known as
+**priority** or **importance**. We add some indicator into the rule definition such as...
 
 ```text
 Rule 1 - Priority 1
@@ -188,9 +188,9 @@ Rule 2 - Priority 10
 
 By default, all rule will be assigned a salience of 0.
 
-This way, its easy for the engine to pick which rule to execute when there are multiple
-conflicting rules. If there are still multiple rule have the top equals priority, the engine
+This way, it's easy for the engine to pick which rule to execute when there are multiple
+conflicting rules. If there are still multiple rules have similarly top priorities, the engine
 will pick the first one found.
 
-Salience can be a value bellow 0 (negative) to ensure the rule have even lower priority, this
-to make sure that the rule will be execute the last after all other rule are met.
+Salience can be a value bellow zero (negative) to ensure the rule have even lower priority, this is
+to make sure that the rule will be execute last after all other rules are met.

--- a/docs/Tutorial_en.md
+++ b/docs/Tutorial_en.md
@@ -9,25 +9,25 @@ Please note that Grule is using Go 1.13
 To import Grule into your project you can simply import it.
 
 ```text
-$ go get github.com/hyperjumptech/grule-rule-engine
+$go get github.com/hyperjumptech/grule-rule-engine
 ```
 
 From your `go` you can import Grule.
 
 ```go
 import (
-	"github.com/hyperjumptech/grule-rule-engine/ast"
-	"github.com/hyperjumptech/grule-rule-engine/builder"
-	"github.com/hyperjumptech/grule-rule-engine/engine"
-	"github.com/hyperjumptech/grule-rule-engine/pkg"
-) 
-``` 
+    "github.com/hyperjumptech/grule-rule-engine/ast"
+    "github.com/hyperjumptech/grule-rule-engine/builder"
+    "github.com/hyperjumptech/grule-rule-engine/engine"
+    "github.com/hyperjumptech/grule-rule-engine/pkg"
+)
+```
 
 ## Creating Fact Structure
 
 A `fact` in grule is a mere **pointer** to an instance of a `struct`.
-This struct may contains properties just like any normal Golang struct, as well
-as `function` or usually, in *OOP*, we call them `method` 
+This struct may contains properties like any normal Golang struct, as well
+as `function` or usually, in *OOP*, we call them `method`
 
 ```go
 type MyFact struct {
@@ -39,10 +39,10 @@ type MyFact struct {
     WhatToSay          string
 }
 
-``` 
+```
 
-Just like normal Golang convention, only **visible** attribute can be accessible
-from Grule rule engine. those with capital first letter.
+Just like normal Golang conventions, only **visible** attributes can be accessible
+from the Grule rule engine, those with capital first letter.
 
 Grule can also call Fact's functions.
 
@@ -52,11 +52,11 @@ func (mf *MyFact) GetWhatToSay(sentence string) string {
 }
 ```
 
-Please note, that there are some convention though.
+Please note, that there are some conventions.
 
 * Member function must be **Visible**, have capital first letter.
 * If the function have returns, there must be only 1 return.
-* Arguments and return, if its an `int`, `uint` or `float`, must be on their 64 bit variant. Eg. `int64`, `uint64`, `float64`.
+* Arguments and return, if it is an `int`, `uint` or `float`, must be their 64-bit variant. Eg. `int64`, `uint64`, `float64`.
 * The function are not encouraged to change the Fact's member attribute, this cause RETE's working memory detection impossible.
 If you **MUST** change some variable, you have to notify Grule using `Changed(varname string)` built-in function.
 
@@ -76,7 +76,7 @@ myFact := &MyFact{
 
 You can create as many fact as you wish.
 
-Now, you have prepare a `DataContext` and add your instance(s) of fact into it.
+Next, you have to prepare a `DataContext` and add your instance(s) of facts into it.
 
 ```go
 dataCtx := ast.NewDataContext()
@@ -91,7 +91,7 @@ if err != nil {
 A `KnowledgeBase` is basically collection of many rules sourced from rule definitions
 loaded from multiple sources.
 
-The DRL, can be in the form of simple string, stored on a file or some where on the internet, are
+The DRL, can be in the form of simple string, stored in a file or somewhere from the internet can each be
 used to build those rules.
 
 Now lets create the `KnowledgeBase`, `WorkingMemory` and then create new `RuleBuilder` to build the rule into prepared `KnowledgeBase`
@@ -124,7 +124,6 @@ if err != nil {
 ### Resources
 
 You can always load a GRL from multiple sources.
-
 
 #### From File
 
@@ -197,7 +196,7 @@ if err != nil {
 
 ## Obtaining Result
 
-If you see, on the rule's GRL above, 
+If you see, on the rule's GRL above,
 
 ```go
 rule CheckValues "Check the default values" salience 10 {
@@ -209,7 +208,7 @@ rule CheckValues "Check the default values" salience 10 {
 }
 ```
 
-The rule modify attribute `MF.WhatToSay` where this is revering to the `WhatToSay` in the 
+The rule modify attribute `MF.WhatToSay` where this is revering to the `WhatToSay` in the
 `MyFact` struct. So simply access that member variable to get the result.
 
 ```go


### PR DESCRIPTION
1. Added a markdown linter to editor
2. Edited md docs to comply with linter
3. Change tabs to spaces
4. Removed spaces at EOL
5. Minor grammar and modify sentence structures for clarity