### PR TITLE
Added support for variadic method calls

### DIFF
--- a/docs/Function_en.md
+++ b/docs/Function_en.md
@@ -415,13 +415,64 @@ dctx := grule.context.NewDataContext()
 dctx.Add("Pogo", &MyPoGo{})
 ```
 
-You can call the fuction within the rule
+You can call the function within the rule
 
 ```go
 when
     Pogo.GetStringLength(some.variable) < 100
 then
     some.variable = Pogo.AppendString(some.variable, "Groooling");
+```
+
+### Variadic Function Arguments
+
+Variadic arguments are supported for custom functions.
+
+```go
+func (p *MyPoGo) GetLongestString(strs... string) string {
+    var longestStr string
+    for _, s := range strs {
+        if len(s) > len(longestStr) {
+            longestStr = s
+        }
+    }
+    return longestStr
+}
+```
+
+This function can then be called from within a rule with zero or more values supplied for the variadic argument
+
+```go
+when
+    Pogo.GetStringLength(some.variable) < 100
+then
+    some.longest = Pogo.GetLongestString(some.stringA, some.stringB, some.stringC);
+```
+
+Since it is possible to provide zero values to satisfy a variadic argument, they can also be used to simulate optional parameters.
+
+```go
+func (p *MyPoGo) AddTax(cost int64, optionalTaxRate... float64) int64 {
+    var taxRate float64 = 0.2
+    if len(optionalTaxRate) > 0 {
+        taxRate = optionalTaxRate[0]
+    }
+    return cost * (1+taxRate)
+}
+```
+
+```go
+when
+    Pogo.IsTaxApplied() == false
+then
+    some.cost = Pogo.AddTax(come.cost);
+
+//or
+
+when
+    Pogo.IsTaxApplied() == false
+then
+    some.cost = Pogo.AddTax(come.cost, 0.15);
 ```
 
 ### Important Thing you must know about Custom Function in Grule

--- a/pkg/reflectools.go
+++ b/pkg/reflectools.go
@@ -23,9 +23,9 @@ func GetFunctionList(obj interface{}) ([]string, error) {
 }
 
 // GetFunctionParameterTypes get list of parameter types of specific function in a struct instance
-func GetFunctionParameterTypes(obj interface{}, methodName string) ([]reflect.Type, error) {
+func GetFunctionParameterTypes(obj interface{}, methodName string) ([]reflect.Type, bool, error) {
 	if !IsStruct(obj) {
-		return nil, errors.Errorf("param is not a struct")
+		return nil, false, errors.Errorf("param is not a struct")
 	}
 	ret := make([]reflect.Type, 0)
 	objType := reflect.TypeOf(obj)
@@ -44,9 +44,9 @@ func GetFunctionParameterTypes(obj interface{}, methodName string) ([]reflect.Ty
 		for i := 1; i < x.NumIn(); i++ {
 			ret = append(ret, x.In(i))
 		}
-		return ret, nil
+		return ret, meth.Type.IsVariadic(), nil
 	}
-	return nil, errors.Errorf("function %s not found", methodName)
+	return nil, false, errors.Errorf("function %s not found", methodName)
 }
 
 // GetFunctionReturnTypes get list of return types of specific function in a struct instance

--- a/pkg/reflectools_test.go
+++ b/pkg/reflectools_test.go
@@ -139,7 +139,7 @@ func TestGetFunctionList(t *testing.T) {
 
 func TestGetFunctionParameterTypes(t *testing.T) {
 	to := &TestObject{}
-	types, err := GetFunctionParameterTypes(to, "FunctionC")
+	types, _, err := GetFunctionParameterTypes(to, "FunctionC")
 	if err != nil {
 		t.Errorf("Error : %v", err)
 		t.FailNow()


### PR DESCRIPTION
Addresses request in issue #56

GetFunctionParameterTypes is modified to return an additional boolean indicating whether or not the methods final parameter is a variadic parameter. If it is, the code iterates over the arguments to fill any non-variadic args, then variadic args are appended to the argument list with a check to ensure each argument is of the same type.
The scenario where variadic arguments are absent is also supported.