### PR TITLE
Handle escaped string constants used in rules

### DIFF
--- a/antlr/GruleParserV2Listener.go
+++ b/antlr/GruleParserV2Listener.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 	"github.com/golang-collections/collections/stack"
@@ -555,7 +556,11 @@ func (s *GruleV2ParserListener) ExitStringLiteral(ctx *parser2.StringLiteralCont
 	if s.StopParse {
 		return
 	}
-	dec := ctx.GetText()[1 : len(ctx.GetText())-1]
+	dec, err := unquoteString(ctx.GetText())
+	if err != nil {
+		s.ErrorCallback(fmt.Errorf("error parsing quoted string (%s): %s", ctx.GetText(), err.Error()))
+		return
+	}
 	if reflect.TypeOf(s.Stack.Peek()).String() == "*ast.Constant" {
 		cons := s.Stack.Peek().(*ast.Constant)
 		cons.Value = reflect.ValueOf(dec)
@@ -579,4 +584,45 @@ func (s *GruleV2ParserListener) ExitBooleanLiteral(ctx *parser2.BooleanLiteralCo
 			cons.Value = reflect.ValueOf(false)
 		}
 	}
+}
+
+func unquoteString(s string) (string, error) {
+	n := len(s)
+	if n < 2 {
+		return "", strconv.ErrSyntax
+	}
+	quote := s[0]
+	if quote != s[n-1] {
+		return "", strconv.ErrSyntax
+	}
+	s = s[1 : n-1]
+
+	if quote != '"' && quote != '\'' {
+		return "", strconv.ErrSyntax
+	}
+
+	if !contains(s, '\\') && !contains(s, quote) && utf8.ValidString(s) {
+		return s, nil
+	}
+
+	var runeTmp [utf8.UTFMax]byte
+	buf := make([]byte, 0, 3*len(s)/2)
+	for len(s) > 0 {
+		c, multibyte, ss, err := strconv.UnquoteChar(s, quote)
+		if err != nil {
+			return "", err
+		}
+		s = ss
+		if c < utf8.RuneSelf || !multibyte {
+			buf = append(buf, byte(c))
+		} else {
+			n := utf8.EncodeRune(runeTmp[:], c)
+			buf = append(buf, runeTmp[:n]...)
+		}
+	}
+	return string(buf), nil
+}
+
+func contains(s string, c byte) bool {
+	return strings.IndexByte(s, c) != -1
 }

--- a/docs/GRL_en.md
+++ b/docs/GRL_en.md
@@ -47,10 +47,12 @@ then
 
 | Literal | Description                                                            | Example                          |
 | ------- | ---------------------------------------------------------------------- | -------------------------------- |
-| String  | Hold string literal, enclosed a string with double quote symbol &quot; or a single quote | "This is a string" or 'this is a string' |
-| Decimal | Hold a decimal value, may preceeded with negative symbol -             | `1` or `34` or `42344` or `-553` |
+| String  | Hold string literal, enclosed a string with double quote symbol &quot; or a single quote ' | "This is a string" or 'this is a string' |
+| Decimal | Hold a decimal value, may preceded with negative symbol -             | `1` or `34` or `42344` or `-553` |
 | Real    | Hold a real value                                                      | `234.4553`, `-234.3` , `314E-2`, `.32` , `12.32E12`  |
 | Boolean | Hold a boolean value                                                   | `true`, `TRUE`, `False`          |
+
+Note: Strings are escaped following the same rules used for standard Go strings. Backtick strings are not supported.
 
 Operators supported :
 


### PR DESCRIPTION
Hi,

I came across an issue with escaped strings in rule definitions. In my application windows file paths are frequently present and need to be compared against known constants.

Our rules did not seem to be working as expected and after some debugging I realised that the engine is not handling escape characters in strings. The result of this is twofold:

1. You cannot have a string constant that ends in a `\` as it will cause a parse error. eg. `"C:\Windows\System32\"`
Escaping the string as you would normally in Go or many other languages will result in the rule not matching because the engine interprets the escaped characters literally.

2. You cannot have a quote inside of the string. If you are using `"` as your quote identifier, it does not appear to be possible to include a quote in the string constant. The same is true when using `'` as the quote identifier.

To fix the issue, this PR will unquote any string constants in as efficient a way as possible. The `unquoteString` function specifically avoids making any allocations in the simple escaping scenarios. It also makes use of the `strings.IndexByte` function which is assembly optimised for speed.

The escaping rules are the same as those which are used for Go strings, including support for escape codes such as `"\n"`. If the string has invalid escape codes then an error will be returned by the parser when loading the rule set.

While I believe this is implementing the intended behaviour of string constants, it is potentially a breaking change for some rules. For example, consider the following rule which will work with the current implementation:

```
rule IsFileInSystemDir "When a file is in a system directory, set the type" {
	when
		Helper.HasPrefix(File.Path, "C:\Windows\System32") || Helper.HasPrefix(File.Path, "C:\Windows\SysWOW64")
	then
		File.Type = "System"
}
```

This rule will now generate a parse error since the strings contain invalid escape codes. The rule can be rewritten correctly as follows:

```
rule IsFileInSystemDir "When a file is in a system directory, set the type" {
	when
		Helper.HasPrefix(File.Path, "C:\\Windows\\System32") || Helper.HasPrefix(File.Path, "C:\\Windows\\SysWOW64")
	then
		File.Type = "System"
}
```

The change also means that you can write rules to match strings that would previously have been impossible. For example, if I wanted to run the same check as above but with the final \ so as not to accidentally match on a directory with a name like `C:\Windows\System32fake\badfile.exe` I could not write the rule in the current version:

```
rule IsFileInSystemDir "When a file is in a system directory, set the type" {
	when
		Helper.HasPrefix(File.Path, "C:\Windows\System32\") || Helper.HasPrefix(File.Path, "C:\Windows\SysWOW64\")
	then
		File.Type = "System"
}
```

Attempting to execute this rule results in a lexer parsing error. With this PR applied, you can write this rule as:

```
rule IsFileInSystemDir "When a file is in a system directory, set the type" {
	when
		Helper.HasPrefix(File.Path, "C:\\Windows\\System32\\") || Helper.HasPrefix(File.Path, "C:\\Windows\\SysWOW64\\")
	then
		File.Type = "System"
}
```

I think it is unlikely that a lot of people have run into this issue previously since there has never been an issue opened, but it may be the case that people have rulesets which are not working the way they expected. If you were to assume that the `\` character was escaping in the same way it was in Go (I fell foul of this myself) then you may have written a rule like the one above which would not match when `File.Path` is `C:\Windows\System32\ntdll.dll` but instead would only match is `File.Path` was something like  `C:\\Windows\\System32\\ntdll.dll`
