### PR TITLE
Feat/knowledge clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,3 +75,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - Variadic function calling
+
+### [1.4.0] - 2020-06-14
+
+#### Added
+
+- Support for `escape` character in string literal
+- `RuleBuilder` is now to build rules in GRLs into `KnowledgeLibrary`
+- Now you should obtain a `KnowledgeBase` instance from `KnowledgeLibrary`. This enable concurrency model in Grule. See `examples/Concurrency_test.go` to know how it works. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,3 +69,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - EventBus implementation for Grule's internal event messaging now replaces the previous simple subscriber approach.
 - Added documentation regarding this EventBus implementation
+
+### [1.3.0] - 2020-06-11
+
+#### Added
+
+- Variadic function calling

--- a/antlr/GruleParserV2_test.go
+++ b/antlr/GruleParserV2_test.go
@@ -5,6 +5,8 @@ import (
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 	parser "github.com/hyperjumptech/grule-rule-engine/antlr/parser/grulev2.g4"
 	"github.com/hyperjumptech/grule-rule-engine/ast"
+	"github.com/hyperjumptech/grule-rule-engine/events"
+	"github.com/hyperjumptech/grule-rule-engine/pkg/eventbus"
 	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"testing"
@@ -47,8 +49,15 @@ func TestV2Parser(t *testing.T) {
 
 		var parseError error
 
-		memory := ast.NewWorkingMemory()
-		kb := ast.NewKnowledgeBase("KB", "1.0.0")
+		memory := ast.NewWorkingMemory("T", "1")
+		kb := &ast.KnowledgeBase{
+			Name:          "T",
+			Version:       "1",
+			DataContext:   nil,
+			WorkingMemory: memory,
+			RuleEntries:   make(map[string]*ast.RuleEntry),
+			Publisher:     eventbus.DefaultBrooker.GetPublisher(events.RuleEngineEventTopic),
+		}
 
 		listener := NewGruleV2ParserListener(kb, memory, func(e error) {
 			parseError = e
@@ -136,8 +145,15 @@ func TestV2Parser2(t *testing.T) {
 
 	var parseError error
 
-	memory := ast.NewWorkingMemory()
-	kb := ast.NewKnowledgeBase("KB", "1.0.0")
+	memory := ast.NewWorkingMemory("T", "1")
+	kb := &ast.KnowledgeBase{
+		Name:          "T",
+		Version:       "1",
+		DataContext:   nil,
+		WorkingMemory: memory,
+		RuleEntries:   make(map[string]*ast.RuleEntry),
+		Publisher:     eventbus.DefaultBrooker.GetPublisher(events.RuleEngineEventTopic),
+	}
 
 	listener := NewGruleV2ParserListener(kb, memory, func(e error) {
 		parseError = e

--- a/antlr/GruleParserV2_test.go
+++ b/antlr/GruleParserV2_test.go
@@ -1,7 +1,6 @@
 package antlr
 
 import (
-	"fmt"
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 	parser "github.com/hyperjumptech/grule-rule-engine/antlr/parser/grulev2.g4"
 	"github.com/hyperjumptech/grule-rule-engine/ast"
@@ -29,14 +28,13 @@ func TestV2Lexer(t *testing.T) {
 			if nt.GetTokenType() == antlr.TokenEOF {
 				break
 			}
-			fmt.Println(nt.GetText())
 		}
 	}
 
 }
 
 func TestV2Parser(t *testing.T) {
-	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetLevel(logrus.InfoLevel)
 	data, err := ioutil.ReadFile("./sample2.grl")
 	if err != nil {
 		t.Fatal(err)
@@ -135,7 +133,7 @@ rule SetTime "When Distance Recorder time not set, set it." {
 )
 
 func TestV2Parser2(t *testing.T) {
-	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetLevel(logrus.InfoLevel)
 
 	sdata := rules
 

--- a/antlr/GruleParserV2_test.go
+++ b/antlr/GruleParserV2_test.go
@@ -179,8 +179,15 @@ func TestV2ParserEscapedStringInvalid(t *testing.T) {
 
 	var parseError error
 
-	memory := ast.NewWorkingMemory()
-	kb := ast.NewKnowledgeBase("KB", "1.0.0")
+	memory := ast.NewWorkingMemory("KB", "1.0.0")
+	kb := &ast.KnowledgeBase{
+		Name:          "KB",
+		Version:       "1.0.0",
+		DataContext:   nil,
+		WorkingMemory: memory,
+		RuleEntries:   make(map[string]*ast.RuleEntry),
+		Publisher:     eventbus.DefaultBrooker.GetPublisher(events.RuleEngineEventTopic),
+	}
 
 	listener := NewGruleV2ParserListener(kb, memory, func(e error) {
 		parseError = e
@@ -204,8 +211,15 @@ func TestV2ParserEscapedStringValid(t *testing.T) {
 
 	var parseError error
 
-	memory := ast.NewWorkingMemory()
-	kb := ast.NewKnowledgeBase("KB", "1.0.0")
+	memory := ast.NewWorkingMemory("KB", "1.0.0")
+	kb := &ast.KnowledgeBase{
+		Name:          "KB",
+		Version:       "1.0.0",
+		DataContext:   nil,
+		WorkingMemory: memory,
+		RuleEntries:   make(map[string]*ast.RuleEntry),
+		Publisher:     eventbus.DefaultBrooker.GetPublisher(events.RuleEngineEventTopic),
+	}
 
 	listener := NewGruleV2ParserListener(kb, memory, func(e error) {
 		parseError = e

--- a/ast/Assignment.go
+++ b/ast/Assignment.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/google/uuid"
+	"github.com/hyperjumptech/grule-rule-engine/pkg"
 	"reflect"
 )
 
@@ -24,6 +25,35 @@ type Assignment struct {
 
 	Variable   *Variable
 	Expression *Expression
+}
+
+// Clone will clone this Assignment. The new clone will have an identical structure
+func (e Assignment) Clone(cloneTable *pkg.CloneTable) *Assignment {
+	clone := &Assignment{
+		AstID:         uuid.New().String(),
+		GrlText:       e.GrlText,
+		DataContext:   nil,
+		WorkingMemory: nil,
+	}
+	if e.Variable != nil {
+		if cloneTable.IsCloned(e.Variable.AstID) {
+			clone.Variable = cloneTable.Records[e.Variable.AstID].CloneInstance.(*Variable)
+		} else {
+			cloned := e.Variable.Clone(cloneTable)
+			clone.Variable = cloned
+			cloneTable.MarkCloned(e.Variable.AstID, cloned.AstID, e.Variable, cloned)
+		}
+	}
+	if e.Expression != nil {
+		if cloneTable.IsCloned(e.Expression.AstID) {
+			clone.Expression = cloneTable.Records[e.Expression.AstID].CloneInstance.(*Expression)
+		} else {
+			cloned := e.Expression.Clone(cloneTable)
+			clone.Expression = cloned
+			cloneTable.MarkCloned(e.Expression.AstID, cloned.AstID, e.Expression, cloned)
+		}
+	}
+	return clone
 }
 
 // InitializeContext will initialize this AST graph with data context and working memory before running rule on them.

--- a/ast/Constant.go
+++ b/ast/Constant.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/google/uuid"
+	"github.com/hyperjumptech/grule-rule-engine/pkg"
 	"reflect"
 )
 
@@ -22,6 +23,19 @@ type Constant struct {
 	DataContext   *DataContext
 	WorkingMemory *WorkingMemory
 	Value         reflect.Value
+}
+
+// Clone will clone this Constant. The new clone will have an identical structure
+func (e Constant) Clone(cloneTable *pkg.CloneTable) *Constant {
+	clone := &Constant{
+		AstID:         uuid.New().String(),
+		GrlText:       e.GrlText,
+		DataContext:   nil,
+		WorkingMemory: nil,
+		Value:         e.Value,
+	}
+
+	return clone
 }
 
 // InitializeContext will initialize this AST graph with data context and working memory before running rule on them.

--- a/ast/Expression.go
+++ b/ast/Expression.go
@@ -68,6 +68,59 @@ type Expression struct {
 	Evaluated bool
 }
 
+// Clone will clone this Expression. The new clone will have an identical structure
+func (e Expression) Clone(cloneTable *pkg.CloneTable) *Expression {
+	clone := &Expression{
+		AstID:         uuid.New().String(),
+		GrlText:       e.GrlText,
+		DataContext:   nil,
+		WorkingMemory: nil,
+		Operator:      e.Operator,
+	}
+
+	if e.LeftExpression != nil {
+		if cloneTable.IsCloned(e.LeftExpression.AstID) {
+			clone.LeftExpression = cloneTable.Records[e.LeftExpression.AstID].CloneInstance.(*Expression)
+		} else {
+			cloned := e.LeftExpression.Clone(cloneTable)
+			clone.LeftExpression = cloned
+			cloneTable.MarkCloned(e.LeftExpression.AstID, cloned.AstID, e.LeftExpression, cloned)
+		}
+	}
+
+	if e.RightExpression != nil {
+		if cloneTable.IsCloned(e.RightExpression.AstID) {
+			clone.RightExpression = cloneTable.Records[e.RightExpression.AstID].CloneInstance.(*Expression)
+		} else {
+			cloned := e.RightExpression.Clone(cloneTable)
+			clone.RightExpression = cloned
+			cloneTable.MarkCloned(e.RightExpression.AstID, cloned.AstID, e.RightExpression, cloned)
+		}
+	}
+
+	if e.SingleExpression != nil {
+		if cloneTable.IsCloned(e.SingleExpression.AstID) {
+			clone.SingleExpression = cloneTable.Records[e.SingleExpression.AstID].CloneInstance.(*Expression)
+		} else {
+			cloned := e.SingleExpression.Clone(cloneTable)
+			clone.SingleExpression = cloned
+			cloneTable.MarkCloned(e.SingleExpression.AstID, cloned.AstID, e.SingleExpression, cloned)
+		}
+	}
+
+	if e.ExpressionAtom != nil {
+		if cloneTable.IsCloned(e.ExpressionAtom.AstID) {
+			clone.ExpressionAtom = cloneTable.Records[e.ExpressionAtom.AstID].CloneInstance.(*ExpressionAtom)
+		} else {
+			cloned := e.ExpressionAtom.Clone(cloneTable)
+			clone.ExpressionAtom = cloned
+			cloneTable.MarkCloned(e.ExpressionAtom.AstID, cloned.AstID, e.ExpressionAtom, cloned)
+		}
+	}
+
+	return clone
+}
+
 // InitializeContext will initialize this AST graph with data context and working memory before running rule on them.
 func (e *Expression) InitializeContext(dataCtx *DataContext, memory *WorkingMemory) {
 	e.DataContext = dataCtx

--- a/ast/FunctionCall.go
+++ b/ast/FunctionCall.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/google/uuid"
+	"github.com/hyperjumptech/grule-rule-engine/pkg"
 	log "github.com/sirupsen/logrus"
 	"reflect"
 )
@@ -26,6 +27,28 @@ type FunctionCall struct {
 	FunctionName string
 	ArgumentList *ArgumentList
 	Value        reflect.Value
+}
+
+// Clone will clone this FunctionCall. The new clone will have an identical structure
+func (e FunctionCall) Clone(cloneTable *pkg.CloneTable) *FunctionCall {
+	clone := &FunctionCall{
+		AstID:         uuid.New().String(),
+		GrlText:       e.GrlText,
+		DataContext:   nil,
+		WorkingMemory: nil,
+		FunctionName:  e.FunctionName,
+	}
+
+	if e.ArgumentList != nil {
+		if cloneTable.IsCloned(e.ArgumentList.AstID) {
+			clone.ArgumentList = cloneTable.Records[e.ArgumentList.AstID].CloneInstance.(*ArgumentList)
+		} else {
+			cloned := e.ArgumentList.Clone(cloneTable)
+			clone.ArgumentList = cloned
+			cloneTable.MarkCloned(e.ArgumentList.AstID, cloned.AstID, e.ArgumentList, cloned)
+		}
+	}
+	return clone
 }
 
 // InitializeContext will initialize this AST graph with data context and working memory before running rule on them.

--- a/ast/MethodCall.go
+++ b/ast/MethodCall.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/google/uuid"
+	"github.com/hyperjumptech/grule-rule-engine/pkg"
 	log "github.com/sirupsen/logrus"
 	"reflect"
 )
@@ -27,6 +28,28 @@ type MethodCall struct {
 	ArgumentList *ArgumentList
 
 	Value reflect.Value
+}
+
+// Clone will clone this MethodCall. The new clone will have an identical structure
+func (e MethodCall) Clone(cloneTable *pkg.CloneTable) *MethodCall {
+	clone := &MethodCall{
+		AstID:         uuid.New().String(),
+		GrlText:       e.GrlText,
+		DataContext:   nil,
+		WorkingMemory: nil,
+		MethodName:    e.MethodName,
+	}
+
+	if e.ArgumentList != nil {
+		if cloneTable.IsCloned(e.ArgumentList.AstID) {
+			clone.ArgumentList = cloneTable.Records[e.ArgumentList.AstID].CloneInstance.(*ArgumentList)
+		} else {
+			cloned := e.ArgumentList.Clone(cloneTable)
+			clone.ArgumentList = cloned
+			cloneTable.MarkCloned(e.ArgumentList.AstID, cloned.AstID, e.ArgumentList, cloned)
+		}
+	}
+	return clone
 }
 
 // InitializeContext will initialize this AST graph with data context and working memory before running rule on them.

--- a/ast/ThenExpression.go
+++ b/ast/ThenExpression.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"github.com/google/uuid"
+	"github.com/hyperjumptech/grule-rule-engine/pkg"
 )
 
 // NewThenExpression create new instance of ThenExpression
@@ -23,6 +24,48 @@ type ThenExpression struct {
 	Assignment   *Assignment
 	FunctionCall *FunctionCall
 	MethodCall   *MethodCall
+}
+
+// Clone will clone this ThenExpression. The new clone will have an identical structure
+func (e ThenExpression) Clone(cloneTable *pkg.CloneTable) *ThenExpression {
+	clone := &ThenExpression{
+		AstID:         uuid.New().String(),
+		GrlText:       e.GrlText,
+		DataContext:   nil,
+		WorkingMemory: nil,
+	}
+
+	if e.Assignment != nil {
+		if cloneTable.IsCloned(e.Assignment.AstID) {
+			clone.Assignment = cloneTable.Records[e.Assignment.AstID].CloneInstance.(*Assignment)
+		} else {
+			cloned := e.Assignment.Clone(cloneTable)
+			clone.Assignment = cloned
+			cloneTable.MarkCloned(e.Assignment.AstID, cloned.AstID, e.Assignment, cloned)
+		}
+	}
+
+	if e.FunctionCall != nil {
+		if cloneTable.IsCloned(e.FunctionCall.AstID) {
+			clone.FunctionCall = cloneTable.Records[e.FunctionCall.AstID].CloneInstance.(*FunctionCall)
+		} else {
+			cloned := e.FunctionCall.Clone(cloneTable)
+			clone.FunctionCall = cloned
+			cloneTable.MarkCloned(e.FunctionCall.AstID, cloned.AstID, e.FunctionCall, cloned)
+		}
+	}
+
+	if e.MethodCall != nil {
+		if cloneTable.IsCloned(e.MethodCall.AstID) {
+			clone.MethodCall = cloneTable.Records[e.MethodCall.AstID].CloneInstance.(*MethodCall)
+		} else {
+			cloned := e.MethodCall.Clone(cloneTable)
+			clone.MethodCall = cloned
+			cloneTable.MarkCloned(e.MethodCall.AstID, cloned.AstID, e.MethodCall, cloned)
+		}
+	}
+
+	return clone
 }
 
 // InitializeContext will initialize this AST graph with data context and working memory before running rule on them.

--- a/ast/ThenExpressionList.go
+++ b/ast/ThenExpressionList.go
@@ -3,6 +3,7 @@ package ast
 import (
 	"bytes"
 	"github.com/google/uuid"
+	"github.com/hyperjumptech/grule-rule-engine/pkg"
 )
 
 // NewThenExpressionList creates new instance of ThenExpressionList
@@ -21,6 +22,31 @@ type ThenExpressionList struct {
 	WorkingMemory *WorkingMemory
 
 	ThenExpressions []*ThenExpression
+}
+
+// Clone will clone this ThenExpressionList. The new clone will have an identical structure
+func (e ThenExpressionList) Clone(cloneTable *pkg.CloneTable) *ThenExpressionList {
+	clone := &ThenExpressionList{
+		AstID:         uuid.New().String(),
+		GrlText:       e.GrlText,
+		DataContext:   nil,
+		WorkingMemory: nil,
+	}
+
+	if e.ThenExpressions != nil {
+		clone.ThenExpressions = make([]*ThenExpression, len(e.ThenExpressions))
+		for k, expr := range e.ThenExpressions {
+			if cloneTable.IsCloned(expr.AstID) {
+				clone.ThenExpressions[k] = cloneTable.Records[expr.AstID].CloneInstance.(*ThenExpression)
+			} else {
+				cloned := expr.Clone(cloneTable)
+				clone.ThenExpressions[k] = cloned
+				cloneTable.MarkCloned(expr.AstID, cloned.AstID, expr, cloned)
+			}
+		}
+	}
+
+	return clone
 }
 
 // InitializeContext will initialize this AST graph with data context and working memory before running rule on them.

--- a/ast/ThenScope.go
+++ b/ast/ThenScope.go
@@ -3,6 +3,7 @@ package ast
 import (
 	"bytes"
 	"github.com/google/uuid"
+	"github.com/hyperjumptech/grule-rule-engine/pkg"
 )
 
 // NewThenScope will create new instance of ThenScope
@@ -20,6 +21,28 @@ type ThenScope struct {
 	WorkingMemory *WorkingMemory
 
 	ThenExpressionList *ThenExpressionList
+}
+
+// Clone will clone this ThenScope. The new clone will have an identical structure
+func (e ThenScope) Clone(cloneTable *pkg.CloneTable) *ThenScope {
+	clone := &ThenScope{
+		AstID:         uuid.New().String(),
+		GrlText:       e.GrlText,
+		DataContext:   nil,
+		WorkingMemory: nil,
+	}
+
+	if e.ThenExpressionList != nil {
+		if cloneTable.IsCloned(e.ThenExpressionList.AstID) {
+			clone.ThenExpressionList = cloneTable.Records[e.ThenExpressionList.AstID].CloneInstance.(*ThenExpressionList)
+		} else {
+			cloned := e.ThenExpressionList.Clone(cloneTable)
+			clone.ThenExpressionList = cloned
+			cloneTable.MarkCloned(e.ThenExpressionList.AstID, cloned.AstID, e.ThenExpressionList, cloned)
+		}
+	}
+
+	return clone
 }
 
 // InitializeContext will initialize this AST graph with data context and working memory before running rule on them.

--- a/ast/Variable.go
+++ b/ast/Variable.go
@@ -3,6 +3,7 @@ package ast
 import (
 	"bytes"
 	"github.com/google/uuid"
+	"github.com/hyperjumptech/grule-rule-engine/pkg"
 	"reflect"
 )
 
@@ -23,6 +24,18 @@ type Variable struct {
 
 	Name  string
 	Value reflect.Value
+}
+
+// Clone will clone this Variable. The new clone will have an identical structure
+func (e Variable) Clone(cloneTable *pkg.CloneTable) *Variable {
+	clone := &Variable{
+		AstID:         uuid.New().String(),
+		GrlText:       e.GrlText,
+		DataContext:   nil,
+		WorkingMemory: nil,
+		Name:          e.Name,
+	}
+	return clone
 }
 
 // InitializeContext will initialize this AST graph with data context and working memory before running rule on them.

--- a/ast/WhenScope.go
+++ b/ast/WhenScope.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"github.com/google/uuid"
+	"github.com/hyperjumptech/grule-rule-engine/pkg"
 	"reflect"
 )
 
@@ -22,6 +23,28 @@ type WhenScope struct {
 	WorkingMemory *WorkingMemory
 
 	Expression *Expression
+}
+
+// Clone will clone this Clone. The new clone will have an identical structure
+func (e WhenScope) Clone(cloneTable *pkg.CloneTable) *WhenScope {
+	clone := &WhenScope{
+		AstID:         uuid.New().String(),
+		GrlText:       e.GrlText,
+		DataContext:   nil,
+		WorkingMemory: nil,
+	}
+
+	if e.Expression != nil {
+		if cloneTable.IsCloned(e.Expression.AstID) {
+			clone.Expression = cloneTable.Records[e.Expression.AstID].CloneInstance.(*Expression)
+		} else {
+			cloned := e.Expression.Clone(cloneTable)
+			clone.Expression = cloned
+			cloneTable.MarkCloned(e.Expression.AstID, cloned.AstID, e.Expression, cloned)
+		}
+	}
+
+	return clone
 }
 
 // InitializeContext will initialize this AST graph with data context and working memory before running rule on them.

--- a/ast/WhenScope_test.go
+++ b/ast/WhenScope_test.go
@@ -41,7 +41,7 @@ func TestNewWhenScope(t *testing.T) {
 		t.Fatalf("Not Error when second time time accept expression")
 	}
 
-	wm := NewWorkingMemory()
+	wm := NewWorkingMemory("T", "1")
 	dt := NewDataContext()
 	test := &TestStructShenScope{
 		StringA: "abc",

--- a/ast/WorkingMemory.go
+++ b/ast/WorkingMemory.go
@@ -2,12 +2,15 @@ package ast
 
 import (
 	"github.com/google/uuid"
+	"github.com/hyperjumptech/grule-rule-engine/pkg"
 	"strings"
 )
 
 // NewWorkingMemory create new instance of WorkingMemory
-func NewWorkingMemory() *WorkingMemory {
+func NewWorkingMemory(name, version string) *WorkingMemory {
 	return &WorkingMemory{
+		Name:                  name,
+		Version:               version,
 		ExpressionSnapshotMap: make(map[string]*Expression),
 		ExpressionVariableMap: make(map[string][]*Expression),
 		ID:                    uuid.New().String(),
@@ -16,19 +19,55 @@ func NewWorkingMemory() *WorkingMemory {
 
 // WorkingMemory handles states of expression evaluation status
 type WorkingMemory struct {
+	Name                  string
+	Version               string
 	ExpressionSnapshotMap map[string]*Expression
 	ExpressionVariableMap map[string][]*Expression
 	ID                    string
 }
 
+// Clone will clone this WorkingMemory. The new clone will have an identical structure
+func (e WorkingMemory) Clone(cloneTable *pkg.CloneTable) *WorkingMemory {
+	clone := NewWorkingMemory(e.Name, e.Version)
+
+	if e.ExpressionSnapshotMap != nil {
+		for k, expr := range e.ExpressionSnapshotMap {
+			if cloneTable.IsCloned(expr.AstID) {
+				clone.ExpressionSnapshotMap[k] = cloneTable.Records[expr.AstID].CloneInstance.(*Expression)
+			} else {
+				cloned := expr.Clone(cloneTable)
+				clone.ExpressionSnapshotMap[k] = cloned
+				cloneTable.MarkCloned(expr.AstID, cloned.AstID, expr, cloned)
+			}
+		}
+	}
+
+	if e.ExpressionVariableMap != nil {
+		for k, exprArr := range e.ExpressionVariableMap {
+			clone.ExpressionVariableMap[k] = make([]*Expression, len(exprArr))
+			for k2, expr := range exprArr {
+				if cloneTable.IsCloned(expr.AstID) {
+					clone.ExpressionVariableMap[k][k2] = cloneTable.Records[expr.AstID].CloneInstance.(*Expression)
+				} else {
+					cloned := expr.Clone(cloneTable)
+					clone.ExpressionVariableMap[k][k2] = cloned
+					cloneTable.MarkCloned(expr.AstID, cloned.AstID, expr, cloned)
+				}
+			}
+		}
+	}
+
+	return clone
+}
+
 // IndexVar will index all expression that contains a speciffic variable name
-func (wm *WorkingMemory) IndexVar(varName string) bool {
+func (e *WorkingMemory) IndexVar(varName string) bool {
 	indexed := false
-	if _, ok := wm.ExpressionVariableMap[varName]; ok == false {
-		wm.ExpressionVariableMap[varName] = make([]*Expression, 0)
-		for snapshot, expr := range wm.ExpressionSnapshotMap {
+	if _, ok := e.ExpressionVariableMap[varName]; ok == false {
+		e.ExpressionVariableMap[varName] = make([]*Expression, 0)
+		for snapshot, expr := range e.ExpressionSnapshotMap {
 			if strings.Contains(snapshot, varName) {
-				wm.ExpressionVariableMap[varName] = append(wm.ExpressionVariableMap[varName], expr)
+				e.ExpressionVariableMap[varName] = append(e.ExpressionVariableMap[varName], expr)
 				indexed = true
 			}
 		}
@@ -38,22 +77,22 @@ func (wm *WorkingMemory) IndexVar(varName string) bool {
 
 // Add will add expression into its map if the expression signature is unique
 // if the expression is already in its map, it will return one from the map.
-func (wm *WorkingMemory) Add(exp *Expression) (*Expression, bool) {
-	if expr, ok := wm.ExpressionSnapshotMap[exp.GetSnapshot()]; ok {
-		AstLog.Tracef("%s : Ignored Expression Snapshot : %s", wm.ID, exp.GetSnapshot())
+func (e *WorkingMemory) Add(exp *Expression) (*Expression, bool) {
+	if expr, ok := e.ExpressionSnapshotMap[exp.GetSnapshot()]; ok {
+		AstLog.Tracef("%s : Ignored Expression Snapshot : %s", e.ID, exp.GetSnapshot())
 		return expr, false
 	}
-	AstLog.Tracef("%s : Added Expression Snapshot : %s", wm.ID, exp.GetSnapshot())
-	wm.ExpressionSnapshotMap[exp.GetSnapshot()] = exp
+	AstLog.Tracef("%s : Added Expression Snapshot : %s", e.ID, exp.GetSnapshot())
+	e.ExpressionSnapshotMap[exp.GetSnapshot()] = exp
 	return exp, true
 }
 
 // Reset will reset the evaluated status of a speciffic expression if its contains a variable name in its signature.
 // Returns true if any expression was reset, false if otherwise
-func (wm *WorkingMemory) Reset(variableName string) bool {
-	AstLog.Tracef("%s : Resetting %s", wm.ID, variableName)
+func (e *WorkingMemory) Reset(variableName string) bool {
+	AstLog.Tracef("%s : Resetting %s", e.ID, variableName)
 	reseted := false
-	if arr, ok := wm.ExpressionVariableMap[variableName]; ok {
+	if arr, ok := e.ExpressionVariableMap[variableName]; ok {
 		for _, expr := range arr {
 			expr.Evaluated = false
 			reseted = true
@@ -64,9 +103,9 @@ func (wm *WorkingMemory) Reset(variableName string) bool {
 
 // ResetAll sets all expression evaluated status to false.
 // Returns true if any expression was reset, false if otherwise
-func (wm *WorkingMemory) ResetAll() bool {
+func (e *WorkingMemory) ResetAll() bool {
 	reseted := false
-	for _, expr := range wm.ExpressionSnapshotMap {
+	for _, expr := range e.ExpressionSnapshotMap {
 		expr.Evaluated = false
 		reseted = true
 	}

--- a/ast/WorkingMemory_test.go
+++ b/ast/WorkingMemory_test.go
@@ -25,7 +25,7 @@ func TestWorkingMemory_Add(t *testing.T) {
 		RightExpression: &Expression{ExpressionAtom: &ExpressionAtom{Variable: &Variable{Name: "some.variable.d"}}},
 		Operator:        OpMul,
 	}
-	wm := NewWorkingMemory()
+	wm := NewWorkingMemory("T", "1")
 	_, added := wm.Add(expr1)
 	if !added {
 		t.Fatalf("Expression not added on the first expression")

--- a/azure-pipelines-1.yml
+++ b/azure-pipelines-1.yml
@@ -1,0 +1,19 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+pr:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- script: echo Hello, world!
+  displayName: 'Run a one-line script'
+
+- script: |
+    echo Add other tasks to build, test, and deploy your project.
+    echo See https://aka.ms/yaml
+  displayName: 'Run a multi-line script'

--- a/builder/RuleBuilder.go
+++ b/builder/RuleBuilder.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"fmt"
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 	antlr2 "github.com/hyperjumptech/grule-rule-engine/antlr"
 	parser2 "github.com/hyperjumptech/grule-rule-engine/antlr/parser/grulev2.g4"
@@ -12,23 +13,21 @@ import (
 )
 
 // NewRuleBuilder creates new RuleBuilder instance. This builder will add all loaded rules into the specified knowledgebase.
-func NewRuleBuilder(KnowledgeBase *ast.KnowledgeBase, memory *ast.WorkingMemory) *RuleBuilder {
+func NewRuleBuilder(KnowledgeLibrary *ast.KnowledgeLibrary) *RuleBuilder {
 	return &RuleBuilder{
-		KnowledgeBase: KnowledgeBase,
-		WorkingMemory: memory,
+		KnowledgeLibrary: KnowledgeLibrary,
 	}
 }
 
 // RuleBuilder builds rule from DRL script into contained KnowledgeBase
 type RuleBuilder struct {
-	KnowledgeBase *ast.KnowledgeBase
-	WorkingMemory *ast.WorkingMemory
+	KnowledgeLibrary *ast.KnowledgeLibrary
 }
 
 // MustBuildRuleFromResources is similar to BuildRuleFromResources, with the difference is, it will panic if rule script contains error.
-func (builder *RuleBuilder) MustBuildRuleFromResources(resource []pkg.Resource) {
+func (builder *RuleBuilder) MustBuildRuleFromResources(name, version string, resource []pkg.Resource) {
 	for _, v := range resource {
-		err := builder.BuildRuleFromResource(v)
+		err := builder.BuildRuleFromResource(name, version, v)
 		if err != nil {
 			panic(err)
 		}
@@ -36,30 +35,30 @@ func (builder *RuleBuilder) MustBuildRuleFromResources(resource []pkg.Resource) 
 }
 
 // MustBuildRuleFromResource is similar to BuildRuleFromResource, with the difference is, it will panic if rule script contains error.
-func (builder *RuleBuilder) MustBuildRuleFromResource(resource pkg.Resource) {
-	if err := builder.BuildRuleFromResource(resource); err != nil {
+func (builder *RuleBuilder) MustBuildRuleFromResource(name, version string, resource pkg.Resource) {
+	if err := builder.BuildRuleFromResource(name, version, resource); err != nil {
 		panic(err)
 	}
 }
 
 // BuildRulesFromBundle will load rules from a bundle into knowledge base.
-func (builder *RuleBuilder) BuildRulesFromBundle(bundle pkg.ResouceBundle) error {
+func (builder *RuleBuilder) BuildRulesFromBundle(name, version string, bundle pkg.ResouceBundle) error {
 	bundles, err := bundle.Load()
 	if err != nil {
 		return err
 	}
-	return builder.BuildRuleFromResources(bundles)
+	return builder.BuildRuleFromResources(name, version, bundles)
 }
 
 // MustBuildRulesFromBundle is the same with BuildRulesFromBundle but it will panic if any error arises during loading resource and inserting it to knowledgebase
-func (builder *RuleBuilder) MustBuildRulesFromBundle(bundle pkg.ResouceBundle) {
-	builder.MustBuildRuleFromResources(bundle.MustLoad())
+func (builder *RuleBuilder) MustBuildRulesFromBundle(name, version string, bundle pkg.ResouceBundle) {
+	builder.MustBuildRuleFromResources(name, version, bundle.MustLoad())
 }
 
 // BuildRuleFromResources will load rules from multiple resources. It will return an error if it encounter an error on the first script it found.
-func (builder *RuleBuilder) BuildRuleFromResources(resource []pkg.Resource) error {
+func (builder *RuleBuilder) BuildRuleFromResources(name, version string, resource []pkg.Resource) error {
 	for _, v := range resource {
-		err := builder.BuildRuleFromResource(v)
+		err := builder.BuildRuleFromResource(name, version, v)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -68,7 +67,7 @@ func (builder *RuleBuilder) BuildRuleFromResources(resource []pkg.Resource) erro
 }
 
 // BuildRuleFromResource will load rules from a single resource. It will return an error if it encounter an error on the specified resource.
-func (builder *RuleBuilder) BuildRuleFromResource(resource pkg.Resource) error {
+func (builder *RuleBuilder) BuildRuleFromResource(name, version string, resource pkg.Resource) error {
 	// save the starting time, we need to see the loading time in debug log
 	startTime := time.Now()
 
@@ -88,7 +87,13 @@ func (builder *RuleBuilder) BuildRuleFromResource(resource pkg.Resource) error {
 	errCall := func(e error) {
 		parseError = e
 	}
-	listener := antlr2.NewGruleV2ParserListener(builder.KnowledgeBase, builder.WorkingMemory, errCall)
+
+	kb := builder.KnowledgeLibrary.GetKnowledgeBase(name, version)
+	if kb == nil {
+		return fmt.Errorf("KnowledgeBase %s:%s is not in this library", name, version)
+	}
+
+	listener := antlr2.NewGruleV2ParserListener(kb, kb.WorkingMemory, errCall)
 
 	psr := parser2.Newgrulev2Parser(stream)
 	psr.BuildParseTrees = true

--- a/docs/FAQ_en.md
+++ b/docs/FAQ_en.md
@@ -102,9 +102,9 @@ There are so many database can potentially store Rule Entries. Creating adapter 
 
 ---
 
-## 3. Maximum number of rule in one knowledgebase
+## 3. Maximum number of rule in one knowledge-base
 
 **Question** : How many rule entry can be inserted into knowledgebase ?
 
-**Answer** : You can have as many rule entries you want. But it should be at least one minimum.
+**Answer** : You can have as many rule entries you want. But there should be at least one minimum.
 

--- a/docs/FAQ_en.md
+++ b/docs/FAQ_en.md
@@ -8,11 +8,11 @@
 
 **Question** : I got the following panic message when Grule engine is executed.
 
-```text
-panic: GruleEngine successfully selected rule candidate for execution after 5000 cycles, this could possibly be caused by rule entry(s) that keep added into execution pool but when executed it does not change any data in context. Please evaluate your rule entries "When" and "Then" scope. You can adjust the maximum cycle using GruleEngine.MaxCycle variable.
+```
+panic: GruleEngine successfully selected rule candidate for execution after 5000 cycles, this could possibly caused by rule entry(s) that keep added into execution pool but when executed it does not change any data in context. Please evaluate your rule entries "When" and "Then" scope. You can adjust the maximum cycle using GruleEngine.MaxCycle variable.
 ```
 
-**Answer** : The rule engine is done by evaluating rule entries for choosing which one to execute in the 5000th time (5000 it the maximum execution cycle). You can specify any positive number but if you have ny doubt, you can leave it to 5000. When the rule set is evaluated more times to this number (the max cycle) it will panic. To fix this issue, have to understand how rule engines work. The following simulation should help you understand the problem and know how to mitigate it.
+**Answer** : The rule engine is done evaluating rule entries for choosing which one to execute in the 5000th time (5000 it the maximum execution cycle). You can change specify any positive number but if you doubt, you an leave it to 5000. When the rule set were evaluated that many times more to this number (the nax cycle) it will panic. To fix this issue, have to understand how rule engine works. The following simulation should help you understand the problem and know how to mitigate it.
 
 Consider this fact.
 
@@ -23,18 +23,18 @@ type Fact struct {
 }
 ```
 
-Where the following rules are defined:
+The following rules defined.
 
 ```text
 rule GiveCashback "Give cashback if payment is above 100" {
-    When
+    When 
          F.Payment > 100
     Then
          F.Cashback = 10;
 }
 
 rule LogCashback "Emit log if cashback is given" {
-    When
+    When 
          F.Cashback > 5
     Then
          Log("Cashback given :" + F.Cashback);
@@ -59,13 +59,13 @@ Cycle n : Execute "GiveCashback" .... because when F.Payment > 100 is a valid co
 Cycle 5000 : Execute "GiveCashback" .... because when F.Payment > 100 is still a valid condition<br>
 panic
 
-You should notice that Grule executes the same rule again and again because the **WHEN** condition keep yielding a valid result.
+You should notice Grule execute the same rule again and again because the **WHEN** condition keep yielding a valid result.
 
-One solution for this is to change "GiveCashback" rule to something like :
+One way for this solution is to change "GiveCashback" rule to something like :
 
 ```text
 rule GiveCashback "Give cashback if payment is above 100" {
-    When
+    When 
          F.Payment > 100 &&
          F.Cashback == 0
     Then
@@ -73,12 +73,12 @@ rule GiveCashback "Give cashback if payment is above 100" {
 }
 ```
 
-This way, after the 1st execution, the rule's WHEN becomes invalid and not get executed again.
+This way, after the 1st execution, the rule's WHEN is become invalid and not get executed again.
 Or ...
 
 ```text
 rule GiveCashback "Give cashback if payment is above 100" {
-    When
+    When 
          F.Payment > 100
     Then
          F.Cashback = 10;
@@ -96,16 +96,15 @@ in the next cycle. When you execute the engine again, all retracted rules will b
 **Question** : Will there be a feature that enable Grule to load/save rules from database ?
 
 **Answer** : No. While it is a good idea to store your rule entries into a database, Grule will not create any database adapter to automaticaly store and retrieve rule from database.
-You can easily create such adapter yourself. Grule have provided a common way to load rules into Knowledgebase from *Reader*, *File*, *Byte Array*, *String* and *Git*. Strings can be easily inserted and selected from database, as you load them into the Grule's knowledgebase.
+You can easily create such adapter your self. Grule have provided a common way to load rules into Knowledgebase from *Reader*, *File*, *Byte Array*, *String* and *Git*. Strings can be easily inserted and selected from database, as you load them into Grule's knowledgebase. 
 
-There are too many database that can potentially be used to store Rule Entries. Creating adapters for those databases means we need to get committed to their driver updates, every single one of them. So we have decided that, if you want to store rule in a database, you can create such mechanism yourself.
-
----
-
-## 3. Maximum number of rule in one knowledge-base
-
-**Question** : How many rule entry can be inserted into the knowledgebase?
-
-**Answer** : You can have as many rule entries as you want, but there should be at least one as a minimum.
+There are so many database can potentially store Rule Entries. Creating adapter for those databases means we need to get committed to their driver updates, every single one of them. So we decide that, if you want to store rule in database, you can create such mechanism your self.
 
 ---
+
+## 3. Maximum number of rule in one knowledgebase
+
+**Question** : How many rule entry can be inserted into knowledgebase ?
+
+**Answer** : You can have as many rule entries you want. But it should be at least one minimum.
+

--- a/docs/Tutorial_en.md
+++ b/docs/Tutorial_en.md
@@ -16,12 +16,12 @@ From your `go` you can import Grule.
 
 ```go
 import (
-    "github.com/hyperjumptech/grule-rule-engine/ast"
-    "github.com/hyperjumptech/grule-rule-engine/builder"
-    "github.com/hyperjumptech/grule-rule-engine/engine"
-    "github.com/hyperjumptech/grule-rule-engine/pkg"
-)
-```
+	"github.com/hyperjumptech/grule-rule-engine/ast"
+	"github.com/hyperjumptech/grule-rule-engine/builder"
+	"github.com/hyperjumptech/grule-rule-engine/engine"
+	"github.com/hyperjumptech/grule-rule-engine/pkg"
+) 
+``` 
 
 ## Creating Fact Structure
 
@@ -187,7 +187,7 @@ To execute the rules, we need to create an instance of `GruleEngine` and with it
 we execute evaluate our `KnowledgeBase` upon the facts in `DataContext`
 
 ```go
-engine := engine.NewGruleEngine()
+engine = engine.NewGruleEngine()
 err = engine.Execute(dataCtx, knowledgeBase, workingMemory)
 if err != nil {
     panic(err)

--- a/docs/Tutorial_en.md
+++ b/docs/Tutorial_en.md
@@ -86,25 +86,27 @@ if err != nil {
 }
 ```
 
-## Creating KnowledgeBase and Adding Rules
+## Creating KnowledgeLibrary and Add Rules Into It
 
-A `KnowledgeBase` is basically collection of many rules sourced from rule definitions
+A `KnowledgeLibrary` is basically collection of `KnowledgeBase` blue prints. 
+And `KnowledgeBase` is a collection of many rules sourced from rule definitions
 loaded from multiple sources.
+We use `RuleBuilder` to build `KnowledgeBase` and add it into `KnowledgeLibrary`
 
 The DRL, can be in the form of simple string, stored in a file or somewhere from the internet can each be
 used to build those rules.
 
-Now lets create the `KnowledgeBase`, `WorkingMemory` and then create new `RuleBuilder` to build the rule into prepared `KnowledgeBase`
+Now lets create the `KnowledgeLibrary` and `RuleBuilder` to build the rule into prepared `KnowledgeLibrary`
 
 ```go
-workingMemory := ast.NewWorkingMemory()
-knowledgeBase := ast.NewKnowledgeBase("tutorial", "1.0.0")
-ruleBuilder := builder.NewRuleBuilder(knowledgeBase, workingMemory)
+knowledgeLibrary := ast.NewKnowledgeLibrary()
+ruleBuilder := builder.NewRuleBuilder(knowledgeLibrary)
 ```
 
 Now we can add rules (defined within a GRL)
 
 ```go
+// lets prepare a rule definition
 drls := `
 rule CheckValues "Check the default values" salience 10 {
     when 
@@ -114,8 +116,10 @@ rule CheckValues "Check the default values" salience 10 {
         Retract("CheckValues);
 }
 `
+
+// Add the rule definition above into the library and name it 'TutorialRules'  version '0.0.1'
 byteArr := pkg.NewBytesResource([]byte(drls))
-err := ruleBuilder.BuildRuleFromResource(byteArr)
+err := ruleBuilder.BuildRuleFromResource("TutorialRules", "0.0.1", byteArr)
 if err != nil {
     panic(err)
 }
@@ -129,7 +133,7 @@ You can always load a GRL from multiple sources.
 
 ```go
 fileRes := pkg.NewFileResource("/path/to/rules.grl")
-err := ruleBuilder.BuildRuleFromResource(fileRes)
+err := ruleBuilder.BuildRuleFromResource("TutorialRules", "0.0.1", fileRes)
 if err != nil {
     panic(err)
 }
@@ -141,7 +145,7 @@ or if you want to get file resource by their pattern
 bundle := pkg.NewFileResourceBundle("/path/to/grls", "/path/to/grls/**/*.grl")
 resources := bundle.MustLoad()
 for _, res := range resources {
-    err := ruleBuilder.BuildRuleFromResource(res)
+    err := ruleBuilder.BuildRuleFromResource("TutorialRules", "0.0.1", res)
     if err != nil {
         panic(err)
     }
@@ -152,7 +156,7 @@ for _, res := range resources {
 
 ```go
 byteArr := pkg.NewBytesResource([]byte(rules))
-err := ruleBuilder.BuildRuleFromResource(byteArr)
+err := ruleBuilder.BuildRuleFromResource("TutorialRules", "0.0.1", byteArr)
 if err != nil {
     panic(err)
 }
@@ -162,7 +166,7 @@ if err != nil {
 
 ```go
 urlRes := pkg.NewUrlResource("http://host.com/path/to/rule.grl")
-err := ruleBuilder.BuildRuleFromResource(urlRes)
+err := ruleBuilder.BuildRuleFromResource("TutorialRules", "0.0.1", urlRes)
 if err != nil {
     panic(err)
 }
@@ -174,21 +178,32 @@ if err != nil {
 bundle := pkg.NewGITResourceBundle("https://github.com/hyperjumptech/grule-rule-engine.git", "/**/*.grl")
 resources := bundle.MustLoad()
 for _, res := range resources {
-    err := ruleBuilder.BuildRuleFromResource(res)
+    err := ruleBuilder.BuildRuleFromResource("TutorialRules", "0.0.1", res)
     if err != nil {
         panic(err)
     }
 }
 ```
 
+Now, in the `KnowledgeLibrary` we have a `KnowledgeBase` named `TutorialRules` with version `0.0.1`. To execute this particular rule, you have to obtain an instance of it from the `KnowledgeLibrary`. This will be explained on the next section.
+
 ## Executing Grule Rule Engine
 
-To execute the rules, we need to create an instance of `GruleEngine` and with it,
-we execute evaluate our `KnowledgeBase` upon the facts in `DataContext`
+To execute a KnowledgeBase, we need to get an instance of this `KnowledgeBase` from `KnowledgeLibrary` 
+
+```go
+knowledgeBase := knowledgeLibrary.NewKnowledgeBaseInstance("Tutorial", "0.0.1")
+```
+
+Each instance you obtained from knowledgeLibrary is a *clone* from the underlying `KnowledgeBase` *blue-print*. Its entirely different instance that makes it *thread-safe* for execution. Each *instance* also carries its own `WorkingMemory`. This is very useful when you want to have a multithreaded execution of rule engine (eg. In a web-server to serve each request using a rule).
+
+Its a significant performance improvement boost since you don't have to "recreate" a `KnowledgeBase` from GRL everytime you start another thread. The `KnowledgeLibrary` will clone the `AST` structure of `KnowledgeBase` into a new instance.
+
+Ok, now lets execute the `KnowledgeBase` instance using the prepared `DataContext`.
 
 ```go
 engine = engine.NewGruleEngine()
-err = engine.Execute(dataCtx, knowledgeBase, workingMemory)
+err = engine.Execute(dataCtx, knowledgeBase)
 if err != nil {
     panic(err)
 }

--- a/engine/GruleEngine.go
+++ b/engine/GruleEngine.go
@@ -33,7 +33,7 @@ type GruleEngine struct {
 
 // Execute function will execute a knowledge evaluation and action against data context.
 // The engine also do conflict resolution of which rule to execute.
-func (g *GruleEngine) Execute(dataCtx *ast.DataContext, knowledge *ast.KnowledgeBase, memory *ast.WorkingMemory) error {
+func (g *GruleEngine) Execute(dataCtx *ast.DataContext, knowledge *ast.KnowledgeBase) error {
 	RuleEnginePublisher := eventbus.DefaultBrooker.GetPublisher(events.RuleEngineEventTopic)
 	RuleEntryPublisher := eventbus.DefaultBrooker.GetPublisher(events.RuleEntryEventTopic)
 
@@ -45,15 +45,13 @@ func (g *GruleEngine) Execute(dataCtx *ast.DataContext, knowledge *ast.Knowledge
 
 	log.Debugf("Starting rule execution using knowledge '%s' version %s. Contains %d rule entries", knowledge.Name, knowledge.Version, len(knowledge.RuleEntries))
 
-	knowledge.WorkingMemory = memory
-
 	// Prepare the timer, we need to measure the processing time in debug mode.
 	startTime := time.Now()
 
 	// Prepare the build-in function and add to datacontext.
 	defunc := &ast.BuildInFunctions{
 		Knowledge:     knowledge,
-		WorkingMemory: memory,
+		WorkingMemory: knowledge.WorkingMemory,
 	}
 	dataCtx.Add("DEFUNC", defunc)
 
@@ -63,7 +61,7 @@ func (g *GruleEngine) Execute(dataCtx *ast.DataContext, knowledge *ast.Knowledge
 
 	// Initialize all AST with datacontext and working memory
 	log.Debugf("Initializing Context")
-	knowledge.InitializeContext(dataCtx, memory)
+	knowledge.InitializeContext(dataCtx)
 
 	var cycle uint64
 

--- a/engine/GruleEngine_test.go
+++ b/engine/GruleEngine_test.go
@@ -108,17 +108,18 @@ func TestGrule_Execute(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	memory := ast.NewWorkingMemory()
-	kb := ast.NewKnowledgeBase("Test", "0.1.1")
-	rb := builder.NewRuleBuilder(kb, memory)
-	err = rb.BuildRuleFromResource(pkg.NewBytesResource([]byte(rules)))
+
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(rules)))
 	if err != nil {
 		t.Errorf("Got error : %v", err)
 		t.FailNow()
 	} else {
 		engine := NewGruleEngine()
+		kb := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
 		start := time.Now()
-		err = engine.Execute(dctx, kb, memory)
+		err = engine.Execute(dctx, kb)
 		if err != nil {
 			t.Errorf("Got error : %v", err)
 			t.FailNow()
@@ -189,18 +190,17 @@ func TestGrule_ExecuteWithSubscribers(t *testing.T) {
 	//	log.Debugf("Now executing rule %s", r.Name)
 	//}
 
-	memory := ast.NewWorkingMemory()
-	kb := ast.NewKnowledgeBase("Test", "0.1.1")
-	rb := builder.NewRuleBuilder(kb, memory)
-	err = rb.BuildRuleFromResource(pkg.NewBytesResource([]byte(rules)))
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(rules)))
 	if err != nil {
 		t.Errorf("Got error : %v", err)
 		t.FailNow()
 	} else {
 		engine := NewGruleEngine()
-
+		kb := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
 		start := time.Now()
-		err = engine.Execute(dctx, kb, memory)
+		err = engine.Execute(dctx, kb)
 		if err != nil {
 			t.Errorf("Got error : %v", err)
 			t.FailNow()
@@ -263,14 +263,14 @@ func TestEngine_ComplexRule1(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	memory := ast.NewWorkingMemory()
-	kb := ast.NewKnowledgeBase("Test", "0.0.1")
-	rb := builder.NewRuleBuilder(kb, memory)
-	err = rb.BuildRuleFromResource(pkg.NewBytesResource([]byte(complexRule1)))
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(complexRule1)))
 	assert.NoError(t, err)
+	kb := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
 
 	engine := NewGruleEngine()
-	err = engine.Execute(dctx, kb, memory)
+	err = engine.Execute(dctx, kb)
 	assert.NoError(t, err)
 
 	assert.Equal(t, int64(1), ts.Result)
@@ -300,14 +300,14 @@ func TestEngine_ComplexRule2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	memory := ast.NewWorkingMemory()
-	kb := ast.NewKnowledgeBase("Test", "0.0.1")
-	rb := builder.NewRuleBuilder(kb, memory)
-	err = rb.BuildRuleFromResource(pkg.NewBytesResource([]byte(complexRule2)))
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(complexRule2)))
 	assert.NoError(t, err)
+	kb := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
 
 	engine := NewGruleEngine()
-	err = engine.Execute(dctx, kb, memory)
+	err = engine.Execute(dctx, kb)
 	assert.NoError(t, err)
 
 	assert.Equal(t, int64(1), ts.Result)
@@ -338,14 +338,14 @@ func TestEngine_ComplexRule3(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	memory := ast.NewWorkingMemory()
-	kb := ast.NewKnowledgeBase("Test", "0.0.1")
-	rb := builder.NewRuleBuilder(kb, memory)
-	err = rb.BuildRuleFromResource(pkg.NewBytesResource([]byte(complexRule3)))
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(complexRule3)))
 	assert.NoError(t, err)
+	kb := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
 
 	engine := NewGruleEngine()
-	err = engine.Execute(dctx, kb, memory)
+	err = engine.Execute(dctx, kb)
 	assert.NoError(t, err)
 
 	assert.Equal(t, int64(1), ts.Result)
@@ -377,14 +377,14 @@ func TestEngine_ComplexRule4(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	memory := ast.NewWorkingMemory()
-	kb := ast.NewKnowledgeBase("Test", "0.0.1")
-	rb := builder.NewRuleBuilder(kb, memory)
-	err = rb.BuildRuleFromResource(pkg.NewBytesResource([]byte(complexRule4)))
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(complexRule4)))
 	assert.NoError(t, err)
+	kb := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
 
 	engine := NewGruleEngine()
-	err = engine.Execute(dctx, kb, memory)
+	err = engine.Execute(dctx, kb)
 	assert.NoError(t, err)
 
 	assert.Equal(t, int64(1), ts.Result)
@@ -408,14 +408,14 @@ func TestEngine_OperatorPrecedence(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	memory := ast.NewWorkingMemory()
-	kb := ast.NewKnowledgeBase("Test", "0.0.1")
-	rb := builder.NewRuleBuilder(kb, memory)
-	err = rb.BuildRuleFromResource(pkg.NewBytesResource([]byte(OpPresedenceRule)))
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(OpPresedenceRule)))
 	assert.NoError(t, err)
+	kb := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
 
 	engine := NewGruleEngine()
-	err = engine.Execute(dctx, kb, memory)
+	err = engine.Execute(dctx, kb)
 	assert.NoError(t, err)
 
 	assert.Equal(t, int64(3), ts.Result)

--- a/engine/GruleEngine_test.go
+++ b/engine/GruleEngine_test.go
@@ -454,17 +454,17 @@ And another`
 	err := dctx.Add("ESTest", es)
 	assert.NoError(t, err)
 
-	memory := ast.NewWorkingMemory()
-	kb := ast.NewKnowledgeBase("Test", "0.0.1")
-	rb := builder.NewRuleBuilder(kb, memory)
-	err = rb.BuildRuleFromResource(pkg.NewBytesResource([]byte(escapedRules)))
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(escapedRules)))
 	assert.NoError(t, err)
+	kb := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
 
 	assert.False(t, es.Result1)
 	assert.False(t, es.Result2)
 
 	engine := NewGruleEngine()
-	err = engine.Execute(dctx, kb, memory)
+	err = engine.Execute(dctx, kb)
 	assert.NoError(t, err)
 
 	assert.True(t, es.Result1)

--- a/examples/AgeCheckSample_test.go
+++ b/examples/AgeCheckSample_test.go
@@ -47,16 +47,16 @@ func TestMyPoGo_GetStringLength(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	memory := ast.NewWorkingMemory()
-	knowledgeBase := ast.NewKnowledgeBase("Test", "0.1.1")
-	ruleBuilder := builder.NewRuleBuilder(knowledgeBase, memory)
+	lib := ast.NewKnowledgeLibrary()
+	ruleBuilder := builder.NewRuleBuilder(lib)
 
-	err = ruleBuilder.BuildRuleFromResource(pkg.NewBytesResource([]byte(rule2)))
+	err = ruleBuilder.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(rule2)))
 	if err != nil {
 		t.Fatal(err)
 	} else {
+		kb := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
 		eng1 := &engine.GruleEngine{MaxCycle: 1}
-		err := eng1.Execute(dataContext, knowledgeBase, memory)
+		err := eng1.Execute(dataContext, kb)
 		if err != nil {
 			t.Fatalf("Got error %v", err)
 		} else {
@@ -82,16 +82,16 @@ func TestMyPoGo_Compare(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	memory := ast.NewWorkingMemory()
-	knowledgeBase := ast.NewKnowledgeBase("Test", "0.1.1")
-	ruleBuilder := builder.NewRuleBuilder(knowledgeBase, memory)
+	lib := ast.NewKnowledgeLibrary()
+	ruleBuilder := builder.NewRuleBuilder(lib)
 
-	err = ruleBuilder.BuildRuleFromResource(pkg.NewBytesResource([]byte(rule3)))
+	err = ruleBuilder.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(rule3)))
 	if err != nil {
-		t.Log(err)
+		t.Fatal(err)
 	} else {
+		kb := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
 		eng1 := &engine.GruleEngine{MaxCycle: 100}
-		err := eng1.Execute(dataContext, knowledgeBase, memory)
+		err := eng1.Execute(dataContext, kb)
 		if err != nil {
 			t.Fatalf("Got error %v", err)
 		} else {

--- a/examples/CallingFactFunctionExample_test.go
+++ b/examples/CallingFactFunctionExample_test.go
@@ -69,16 +69,16 @@ func TestCallingFactFunction(t *testing.T) {
 		panic(err)
 	}
 
-	memory := ast.NewWorkingMemory()
-	knowledgeBase := ast.NewKnowledgeBase("CallingFactFunction", "0.1.1")
-	ruleBuilder := builder.NewRuleBuilder(knowledgeBase, memory)
-
-	err = ruleBuilder.BuildRuleFromResource(pkg.NewBytesResource([]byte(CallFactFuncDRL)))
+	// Prepare knowledgebase library and load it with our rule.
+	lib := ast.NewKnowledgeLibrary()
+	ruleBuilder := builder.NewRuleBuilder(lib)
+	err = ruleBuilder.BuildRuleFromResource("CallingFactFunction", "0.1.1", pkg.NewBytesResource([]byte(CallFactFuncDRL)))
+	knowledgeBase := lib.NewKnowledgeBaseInstance("CallingFactFunction", "0.1.1")
 	if err != nil {
 		panic(err)
 	} else {
 		eng1 := &engine.GruleEngine{MaxCycle: 500}
-		err := eng1.Execute(dataContext, knowledgeBase, memory)
+		err := eng1.Execute(dataContext, knowledgeBase)
 		if err != nil {
 			t.Fatalf("Got error %v", err)
 		}

--- a/examples/CallingLogExample_test.go
+++ b/examples/CallingLogExample_test.go
@@ -24,16 +24,18 @@ rule CallingLog "Calling a log" {
 func TestCallingLog(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 	dataContext := ast.NewDataContext()
-	memory := ast.NewWorkingMemory()
-	knowledgeBase := ast.NewKnowledgeBase("CallingLog", "0.1.1")
-	ruleBuilder := builder.NewRuleBuilder(knowledgeBase, memory)
 
-	err := ruleBuilder.BuildRuleFromResource(pkg.NewBytesResource([]byte(DRL)))
+	lib := ast.NewKnowledgeLibrary()
+	ruleBuilder := builder.NewRuleBuilder(lib)
+	err := ruleBuilder.BuildRuleFromResource("CallingLog", "0.1.1", pkg.NewBytesResource([]byte(DRL)))
 	if err != nil {
 		panic(err)
 	} else {
+
+		knowledgeBase := lib.NewKnowledgeBaseInstance("CallingLog", "0.1.1")
+
 		eng1 := &engine.GruleEngine{MaxCycle: 1}
-		err := eng1.Execute(dataContext, knowledgeBase, memory)
+		err := eng1.Execute(dataContext, knowledgeBase)
 		if err != nil {
 			t.Fatalf("Got error %v", err)
 		}

--- a/examples/Concurrency_test.go
+++ b/examples/Concurrency_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hyperjumptech/grule-rule-engine/builder"
 	"github.com/hyperjumptech/grule-rule-engine/engine"
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
+	"github.com/sirupsen/logrus"
 	"sync"
 	"testing"
 	"time"
@@ -39,6 +40,11 @@ var (
 
 	// syncD is a mutex object to protect threadFinishMap from concurrent map read/write
 	syncD = sync.Mutex{}
+
+	concurrencyTestlog = logrus.WithFields(logrus.Fields{
+		"lib":  "grule",
+		"file": "examples/Concurrency_test.go",
+	})
 )
 
 // Vibonaci our model
@@ -76,7 +82,7 @@ func isAllThreadFinished() bool {
 }
 
 func beginThread(threadName string, lib *ast.KnowledgeLibrary, t *testing.T) {
-	t.Logf("Beginning thread %s", threadName)
+	concurrencyTestlog.Tracef("Beginning thread %s", threadName)
 
 	// Register this thread into our simple finish map check
 	startThread(threadName)
@@ -119,10 +125,12 @@ func beginThread(threadName string, lib *ast.KnowledgeLibrary, t *testing.T) {
 	}
 
 	// We are done.
-	t.Logf("Finishing thread %s, Count:%d, A:%d,B:%d,C:%d", threadName, vibo.Count, vibo.A, vibo.B, vibo.C)
+	concurrencyTestlog.Tracef("Finishing thread %s, Count:%d, A:%d,B:%d,C:%d", threadName, vibo.Count, vibo.A, vibo.B, vibo.C)
 }
 
 func TestConcurrency(t *testing.T) {
+	logrus.SetLevel(logrus.InfoLevel)
+
 	// Prepare knowledgebase library and load it with our rule.
 	lib := ast.NewKnowledgeLibrary()
 	rb := builder.NewRuleBuilder(lib)

--- a/examples/Concurrency_test.go
+++ b/examples/Concurrency_test.go
@@ -1,0 +1,144 @@
+package examples
+
+import (
+	"fmt"
+	"github.com/hyperjumptech/grule-rule-engine/ast"
+	"github.com/hyperjumptech/grule-rule-engine/builder"
+	"github.com/hyperjumptech/grule-rule-engine/engine"
+	"github.com/hyperjumptech/grule-rule-engine/pkg"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	VibonaciRule = `
+rule PrepareVibonaci "Preparing Vibonaci" salience 10 {
+	when 
+		Vibo.A == 0 || Vibo.B == 0
+	then
+		Vibo.A = 1;
+		Vibo.B = 1;
+}
+
+rule ExecuteVibonaci "Vibonaci execution" salience 10 {
+	when 
+		Vibo.Count < 80 && Vibo.A > 0 && Vibo.B > 0
+	then
+		Vibo.Count = Vibo.Count + 1;
+		Vibo.C = Vibo.A + Vibo.B;
+		Vibo.A = Vibo.B;
+		Vibo.B = Vibo.C;
+}
+`
+)
+
+var (
+	// threadFinishMap used to monitor the status of all thread
+	threadFinishMap = make(map[string]bool)
+
+	// syncD is a mutex object to protect threadFinishMap from concurrent map read/write
+	syncD = sync.Mutex{}
+)
+
+// Vibonaci our model
+type Vibonaci struct {
+	fmt.Stringer
+	Count int
+	A     uint
+	B     uint
+	C     uint
+}
+
+func startThread(threadName string) {
+	syncD.Lock()
+	defer syncD.Unlock()
+	threadFinishMap[threadName] = false
+}
+
+func finishThread(threadName string) {
+	syncD.Lock()
+	defer syncD.Unlock()
+	threadFinishMap[threadName] = true
+}
+
+func isAllThreadFinished() bool {
+	syncD.Lock()
+	defer syncD.Unlock()
+	fin := true
+	for _, b := range threadFinishMap {
+		fin = fin && b
+		if !fin {
+			return false
+		}
+	}
+	return true
+}
+
+func beginThread(threadName string, lib *ast.KnowledgeLibrary, t *testing.T) {
+	t.Logf("Beginning thread %s", threadName)
+
+	// Register this thread into our simple finish map check
+	startThread(threadName)
+	defer finishThread(threadName)
+
+	// Prepare new DataContext to be used in this Thread
+	dataContext := ast.NewDataContext()
+
+	// Create our model and add into data context
+	vibo := &Vibonaci{}
+	err := dataContext.Add("Vibo", vibo)
+	if err != nil {
+		t.Fatalf("DataContext error on thread %s, got %s", threadName, err)
+	}
+
+	// Create a new engine for this thread
+	engine := &engine.GruleEngine{MaxCycle: 100}
+
+	// Get an instance of our KnowledgeBase from KnowledgeLibrary
+	kb := lib.NewKnowledgeBaseInstance("VibonaciTest", "0.0.1")
+
+	// Execute the KnowledgeBase against DataContext
+	err = engine.Execute(dataContext, kb)
+	if err != nil {
+		t.Fatalf("Engine execution error on thread %s, got %s", threadName, err)
+	}
+
+	// Make sure this thread result a consistent result
+	if vibo.Count != 80 {
+		t.Errorf("%s Expected vibo.Count == 80 but %d", threadName, vibo.Count)
+	}
+	if vibo.A != 37889062373143906 {
+		t.Errorf("%s Expected vibo.A == 37889062373143906 but %d", threadName, vibo.Count)
+	}
+	if vibo.B != 61305790721611591 {
+		t.Errorf("%s Expected vibo.B == 61305790721611591 but %d", threadName, vibo.Count)
+	}
+	if vibo.C != 61305790721611591 {
+		t.Errorf("%s Expected vibo.C == 61305790721611591 but %d", threadName, vibo.Count)
+	}
+
+	// We are done.
+	t.Logf("Finishing thread %s, Count:%d, A:%d,B:%d,C:%d", threadName, vibo.Count, vibo.A, vibo.B, vibo.C)
+}
+
+func TestConcurrency(t *testing.T) {
+	// Prepare knowledgebase library and load it with our rule.
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err := rb.BuildRuleFromResource("VibonaciTest", "0.0.1", pkg.NewBytesResource([]byte(VibonaciRule)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Now start 500 thread that uses the KnowledgeLibrary
+	for i := 1; i <= 500; i++ {
+		go beginThread(fmt.Sprintf("T%d", i), lib, t)
+	}
+
+	// Wait until all thread finishes
+	time.Sleep(1 * time.Second)
+	for !isAllThreadFinished() {
+		time.Sleep(500 * time.Millisecond)
+	}
+}

--- a/examples/Issue4_test.go
+++ b/examples/Issue4_test.go
@@ -52,16 +52,16 @@ func TestMethodCall_Issue4(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mem := ast.NewWorkingMemory()
-	knowledgeBase := ast.NewKnowledgeBase("Test", "0.1.1")
-	ruleBuilder := builder.NewRuleBuilder(knowledgeBase, mem)
-
-	err = ruleBuilder.BuildRuleFromResource(pkg.NewBytesResource([]byte(Rule4)))
+	// Prepare knowledgebase library and load it with our rule.
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(Rule4)))
 	if err != nil {
 		t.Fatal(err)
 	} else {
+		kb := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
 		eng1 := &engine.GruleEngine{MaxCycle: 3}
-		err := eng1.Execute(dataContext, knowledgeBase, mem)
+		err := eng1.Execute(dataContext, kb)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/examples/Issue5_test.go
+++ b/examples/Issue5_test.go
@@ -43,16 +43,16 @@ func TestMethodCall_Issue5(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mem := ast.NewWorkingMemory()
-	knowledgeBase := ast.NewKnowledgeBase("Test", "0.1.1")
-	ruleBuilder := builder.NewRuleBuilder(knowledgeBase, mem)
-
-	err = ruleBuilder.BuildRuleFromResource(pkg.NewBytesResource([]byte(Rule)))
+	// Prepare knowledgebase library and load it with our rule.
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(Rule)))
 	if err != nil {
 		t.Log(err)
 	} else {
 		eng1 := &engine.GruleEngine{MaxCycle: 5}
-		err := eng1.Execute(dataContext, knowledgeBase, mem)
+		kb := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
+		err := eng1.Execute(dataContext, kb)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/examples/Issue7_test.go
+++ b/examples/Issue7_test.go
@@ -45,16 +45,16 @@ func TestMethodCall_Issue7(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mem := ast.NewWorkingMemory()
-	knowledgeBase := ast.NewKnowledgeBase("Test", "0.1.1")
-	ruleBuilder := builder.NewRuleBuilder(knowledgeBase, mem)
-
-	err = ruleBuilder.BuildRuleFromResource(pkg.NewBytesResource([]byte(Rule7)))
+	// Prepare knowledgebase library and load it with our rule.
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(Rule7)))
 	if err != nil {
 		t.Log(err)
 	} else {
 		eng1 := &engine.GruleEngine{MaxCycle: 5}
-		err := eng1.Execute(dataContext, knowledgeBase, mem)
+		kb := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
+		err := eng1.Execute(dataContext, kb)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/examples/ItemArrayExample.go
+++ b/examples/ItemArrayExample.go
@@ -60,14 +60,16 @@ func (cf *ItemPriceChecker) CheckPrices() {
 		Price: 110,
 	})
 
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+
 	// Prepare knowledgebase and load it with our rule.
-	memory := ast.NewWorkingMemory()
-	kb := ast.NewKnowledgeBase("PriceCheck", "0.0.1")
-	rb := builder.NewRuleBuilder(kb, memory)
-	err := rb.BuildRuleFromResource(pkg.NewBytesResource([]byte(PriceCheckRule1)))
+	err := rb.BuildRuleFromResource("PriceCheck", "0.0.1", pkg.NewBytesResource([]byte(PriceCheckRule1)))
 	if err != nil {
 		panic(err)
 	}
+
+	kb := lib.NewKnowledgeBaseInstance("PriceCheck", "0.0.1")
 
 	// Prepare the engine
 	eng := engine.NewGruleEngine()
@@ -81,7 +83,7 @@ func (cf *ItemPriceChecker) CheckPrices() {
 		if err != nil {
 			panic(err)
 		}
-		err = eng.Execute(dctx, kb, memory)
+		err = eng.Execute(dctx, kb)
 		if err != nil {
 			panic(err)
 		}
@@ -146,14 +148,15 @@ func (cf *ItemPriceChecker) CheckCart() {
 	})
 	cart := &ItemCart{Items: items}
 
-	// Prepare knowledgebase and load it with our rule.
-	mem := ast.NewWorkingMemory()
-	kb := ast.NewKnowledgeBase("Cart Check Rules", "0.0.1")
-	rb := builder.NewRuleBuilder(kb, mem)
-	err := rb.BuildRuleFromResource(pkg.NewBytesResource([]byte(PriceCheckRule2)))
+	// Prepare knowledgebase library and load it with our rule.
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err := rb.BuildRuleFromResource("Cart Check Rules", "0.0.1", pkg.NewBytesResource([]byte(PriceCheckRule2)))
 	if err != nil {
 		panic(err)
 	}
+
+	kb := lib.NewKnowledgeBaseInstance("Cart Check Rules", "0.0.1")
 
 	// Prepare the engine
 	eng := engine.NewGruleEngine()
@@ -163,7 +166,7 @@ func (cf *ItemPriceChecker) CheckCart() {
 	if err != nil {
 		panic(err)
 	}
-	err = eng.Execute(dctx, kb, mem)
+	err = eng.Execute(dctx, kb)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/ItemArrayExample_test.go
+++ b/examples/ItemArrayExample_test.go
@@ -33,10 +33,11 @@ func TestItemPriceChecker_TestParser(t *testing.T) {
 	lexer := parser2.Newgrulev2Lexer(nis)
 	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
 
-	mem := ast.NewWorkingMemory()
+	lib := ast.NewKnowledgeLibrary()
+	kb := lib.GetKnowledgeBase("Test", "0.1.1")
 
 	var parseError error
-	listener := antlr2.NewGruleV2ParserListener(ast.NewKnowledgeBase("Test", "0.1.1"), mem, func(e error) {
+	listener := antlr2.NewGruleV2ParserListener(kb, kb.WorkingMemory, func(e error) {
 		parseError = e
 	})
 

--- a/examples/PurcasingTaxSample.go
+++ b/examples/PurcasingTaxSample.go
@@ -109,21 +109,19 @@ type CashFlowCalculator struct {
 func (cf *CashFlowCalculator) CalculatePurchases() {
 	cashFlow := &CashFlow{}
 
-	mem := ast.NewWorkingMemory()
-	kb := ast.NewKnowledgeBase("Purchase Calculator", "0.0.1")
-	rb := builder.NewRuleBuilder(kb, mem)
-	err := rb.BuildRuleFromResource(pkg.NewFileResource("CashFlowRule.grl"))
-	if err != nil {
-		panic(err)
-	}
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err := rb.BuildRuleFromResource("Purchase Calculator", "0.0.1", pkg.NewFileResource("CashFlowRule.grl"))
 
 	engine := engine2.NewGruleEngine()
+
+	kb := lib.NewKnowledgeBaseInstance("Purchase Calculator", "0.0.1")
 
 	for _, purchase := range Purchases {
 		dctx := ast.NewDataContext()
 		dctx.Add("CashFlow", cashFlow)
 		dctx.Add("Purchase", purchase)
-		err = engine.Execute(dctx, kb, mem)
+		err = engine.Execute(dctx, kb)
 		if err != nil {
 			panic(err)
 		}

--- a/examples/SalienceExample_test.go
+++ b/examples/SalienceExample_test.go
@@ -99,16 +99,19 @@ func TestSalience(t *testing.T) {
 		},
 	}
 
-	workingMemory := ast.NewWorkingMemory()
-	knowledgeBase := ast.NewKnowledgeBase("Tutorial", "0.0.1")
-	ruleBuilder := builder.NewRuleBuilder(knowledgeBase, workingMemory)
+	// Prepare knowledgebase library and load it with our rule.
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
 	byteArr := pkg.NewBytesResource([]byte(SalienceDRL))
-	err := ruleBuilder.BuildRuleFromResource(byteArr)
+	err := rb.BuildRuleFromResource("Tutorial", "0.0.1", byteArr)
+
 	if err != nil {
 		panic(err)
 	}
 
 	engine := engine.NewGruleEngine()
+
+	knowledgeBase := lib.NewKnowledgeBaseInstance("Tutorial", "0.0.1")
 
 	for _, td := range testData {
 		dataCtx := ast.NewDataContext()
@@ -117,7 +120,7 @@ func TestSalience(t *testing.T) {
 			panic(err)
 		}
 
-		err = engine.Execute(dataCtx, knowledgeBase, workingMemory)
+		err = engine.Execute(dataCtx, knowledgeBase)
 		if err != nil {
 			panic(err)
 		}

--- a/examples/TutorialExample_test.go
+++ b/examples/TutorialExample_test.go
@@ -39,9 +39,9 @@ func TestTutorial(t *testing.T) {
 		panic(err)
 	}
 
-	workingMemory := ast.NewWorkingMemory()
-	knowledgeBase := ast.NewKnowledgeBase("Tutorial", "0.0.1")
-	ruleBuilder := builder.NewRuleBuilder(knowledgeBase, workingMemory)
+	// Prepare knowledgebase library and load it with our rule.
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
 
 	drls := `
 rule CheckValues "Check the default values" salience 10 {
@@ -52,14 +52,16 @@ rule CheckValues "Check the default values" salience 10 {
 		Retract("CheckValues");
 }
 `
-	byteArr := pkg.NewBytesResource([]byte(drls))
-	err = ruleBuilder.BuildRuleFromResource(byteArr)
+
+	err = rb.BuildRuleFromResource("Tutorial", "0.0.1", pkg.NewBytesResource([]byte(drls)))
 	if err != nil {
 		panic(err)
 	}
 
+	knowledgeBase := lib.NewKnowledgeBaseInstance("Tutorial", "0.0.1")
+
 	engine := engine.NewGruleEngine()
-	err = engine.Execute(dataCtx, knowledgeBase, workingMemory)
+	err = engine.Execute(dataCtx, knowledgeBase)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/TutorialExample_test.go
+++ b/examples/TutorialExample_test.go
@@ -40,8 +40,8 @@ func TestTutorial(t *testing.T) {
 	}
 
 	// Prepare knowledgebase library and load it with our rule.
-	lib := ast.NewKnowledgeLibrary()
-	rb := builder.NewRuleBuilder(lib)
+	knowledgeLibrary := ast.NewKnowledgeLibrary()
+	ruleBuilder := builder.NewRuleBuilder(knowledgeLibrary)
 
 	drls := `
 rule CheckValues "Check the default values" salience 10 {
@@ -52,13 +52,13 @@ rule CheckValues "Check the default values" salience 10 {
 		Retract("CheckValues");
 }
 `
-
-	err = rb.BuildRuleFromResource("Tutorial", "0.0.1", pkg.NewBytesResource([]byte(drls)))
+	byteArr := pkg.NewBytesResource([]byte(drls))
+	err = ruleBuilder.BuildRuleFromResource("Tutorial", "0.0.1", byteArr)
 	if err != nil {
 		panic(err)
 	}
 
-	knowledgeBase := lib.NewKnowledgeBaseInstance("Tutorial", "0.0.1")
+	knowledgeBase := knowledgeLibrary.NewKnowledgeBaseInstance("Tutorial", "0.0.1")
 
 	engine := engine.NewGruleEngine()
 	err = engine.Execute(dataCtx, knowledgeBase)

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,7 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 h1:sfkvUWPNGwSV+8/fNqctR5lS2AqCSqYwXdrjCxp/dXo=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/pkg/CloneTool.go
+++ b/pkg/CloneTool.go
@@ -1,0 +1,35 @@
+package pkg
+
+// CloneRecord contains information about all AST versions, instance, their cloned version and cloned instance.
+type CloneRecord struct {
+	OriginAstID    string
+	CloneAstID     string
+	OriginInstance interface{}
+	CloneInstance  interface{}
+}
+
+// NewCloneTable create new instance of CloneTable
+func NewCloneTable() *CloneTable {
+	return &CloneTable{Records: make(map[string]*CloneRecord)}
+}
+
+// CloneTable will stores all meta information about AST object being cloned under one KnowledgeBase.
+type CloneTable struct {
+	Records map[string]*CloneRecord
+}
+
+// IsCloned will check if an AST object with identified astId has a clone.
+func (tab *CloneTable) IsCloned(astID string) bool {
+	_, ok := tab.Records[astID]
+	return ok
+}
+
+// MarkCloned will record that an Ast object are now been cloned, so all other cloned object should reference to the newly cloned Ast object
+func (tab *CloneTable) MarkCloned(originAst, cloneAst string, origin, clone interface{}) {
+	tab.Records[originAst] = &CloneRecord{
+		OriginAstID:    originAst,
+		CloneAstID:     cloneAst,
+		OriginInstance: origin,
+		CloneInstance:  clone,
+	}
+}

--- a/pkg/jsontool/JsonDom.go
+++ b/pkg/jsontool/JsonDom.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 )
 
+// NewJsonData will create a new instance of JsonData
 func NewJsonData(jsonData []byte) (*JsonData, error) {
 	var tm interface{}
 
@@ -18,30 +19,37 @@ func NewJsonData(jsonData []byte) (*JsonData, error) {
 	return &JsonData{jsonRoot: tm}, nil
 }
 
+// JsonNode represent a node in JSON Tree
 type JsonNode struct {
 	interf interface{}
 }
 
+// IsArray will check if this node represent an array
 func (n *JsonNode) IsArray() bool {
 	return reflect.TypeOf(n.interf).String() == "[]interface {}"
 }
 
+// IsMap will check if this node represent a Map
 func (n *JsonNode) IsMap() bool {
 	return reflect.TypeOf(n.interf).String() == "map[string]interface {}"
 }
 
+// IsString check if this node represent a string
 func (n *JsonNode) IsString() bool {
 	return reflect.TypeOf(n.interf).String() == "string"
 }
 
+// IsBool check if this node represent a boolean
 func (n *JsonNode) IsBool() bool {
 	return reflect.TypeOf(n.interf).String() == "bool"
 }
 
+// IsFloat check if this node represent a float
 func (n *JsonNode) IsFloat() bool {
 	return reflect.TypeOf(n.interf).String() == "float64"
 }
 
+// IsInt checks if this node represent an int
 func (n *JsonNode) IsInt() bool {
 	if reflect.TypeOf(n.interf).String() == "float64" {
 		v := reflect.ValueOf(n.interf)
@@ -53,6 +61,7 @@ func (n *JsonNode) IsInt() bool {
 	return true
 }
 
+// Len return length of element in this array. Will panic if this node is not an array
 func (n *JsonNode) Len() int {
 	if !n.IsArray() {
 		panic("Not array")
@@ -61,7 +70,8 @@ func (n *JsonNode) Len() int {
 	return len(arr)
 }
 
-func (n *JsonNode) NodeAt(index int) *JsonNode {
+// GetNodeAt will get the child not on specific index. Will panic if this not is not an array
+func (n *JsonNode) GetNodeAt(index int) *JsonNode {
 	if !n.IsArray() {
 		panic("Not array")
 	}
@@ -69,6 +79,7 @@ func (n *JsonNode) NodeAt(index int) *JsonNode {
 	return &JsonNode{interf: arr[index]}
 }
 
+// HaveKey will check if the map contains specified key. Will panic if this node is not a map
 func (n *JsonNode) HaveKey(key string) bool {
 	if !n.IsMap() {
 		panic("Not map")
@@ -80,6 +91,7 @@ func (n *JsonNode) HaveKey(key string) bool {
 	return false
 }
 
+// Get will fetch the child not designated with specified key. Will panic if this node is not a map
 func (n *JsonNode) Get(key string) *JsonNode {
 	if !n.IsMap() {
 		panic("Not map")
@@ -88,6 +100,16 @@ func (n *JsonNode) Get(key string) *JsonNode {
 	return &JsonNode{interf: amap[key]}
 }
 
+// Set will set the value of a map designated with specified key. Will panic if this node is not a map
+func (n *JsonNode) Set(key string, node *JsonNode) {
+	if !n.IsMap() {
+		panic("Not map")
+	}
+	amap := n.interf.(map[string]interface{})
+	amap[key] = node.interf
+}
+
+// GetString will get the string value of this node. Will panic if this node is not a string
 func (n *JsonNode) GetString() string {
 	if !n.IsString() {
 		panic("Not string")
@@ -95,6 +117,15 @@ func (n *JsonNode) GetString() string {
 	return n.interf.(string)
 }
 
+// SetString will set this node value with a string value. Will panic if this node is not a string
+func (n *JsonNode) SetString(val string) {
+	if !n.IsString() {
+		panic("Not string")
+	}
+	n.interf = val
+}
+
+// GetBool will get the bool value of this node. Will panic if this node is not a boolean
 func (n *JsonNode) GetBool() bool {
 	if !n.IsBool() {
 		panic("Not boolean")
@@ -102,6 +133,15 @@ func (n *JsonNode) GetBool() bool {
 	return n.interf.(bool)
 }
 
+// SetBool will set this node value with boolean value, will panic if this node is not a bool
+func (n *JsonNode) SetBool(val bool) {
+	if !n.IsBool() {
+		panic("Not boolean")
+	}
+	n.interf = val
+}
+
+// GetFloat will get the float value of this node. Will panic if this node is not a float.
 func (n *JsonNode) GetFloat() float64 {
 	if !n.IsFloat() {
 		panic("Not float")
@@ -109,6 +149,15 @@ func (n *JsonNode) GetFloat() float64 {
 	return n.interf.(float64)
 }
 
+// SetFloat will set this node value with float value. Will panic if this node is not a float
+func (n *JsonNode) SetFloat(val float64) {
+	if !n.IsFloat() {
+		panic("Not float")
+	}
+	n.interf = val
+}
+
+// GetInt will get the int value of this node. Will panic if this node is not an int
 func (n *JsonNode) GetInt() int {
 	if !n.IsInt() {
 		panic("Not int")
@@ -117,10 +166,20 @@ func (n *JsonNode) GetInt() int {
 	return int(fl)
 }
 
+// SetInt will set this node value with int value. Will panic if this node is not an int
+func (n *JsonNode) SetInt(val int) {
+	if !n.IsInt() {
+		panic("Not int")
+	}
+	n.interf = float64(val)
+}
+
+// JsonData represent a whole Json construct.
 type JsonData struct {
 	jsonRoot interface{}
 }
 
+// GetRootNode will return the root node of this JsonData
 func (jo *JsonData) GetRootNode() *JsonNode {
 	if jo.jsonRoot == nil {
 		panic(fmt.Sprintf("root node is nil"))
@@ -128,6 +187,7 @@ func (jo *JsonData) GetRootNode() *JsonNode {
 	return &JsonNode{interf: jo.jsonRoot}
 }
 
+// IsValidPath will check if the provided path is valid
 func (jo *JsonData) IsValidPath(path string) bool {
 	if len(path) == 0 {
 		return true
@@ -137,6 +197,7 @@ func (jo *JsonData) IsValidPath(path string) bool {
 	return jo.validPathCheck(pathArr, node)
 }
 
+// validPathCheck is recursion function to traverse the json tree for checking valid path
 func (jo *JsonData) validPathCheck(pathArr []string, node *JsonNode) bool {
 	if len(pathArr) == 0 && (node.IsString() || node.IsInt() || node.IsFloat() || node.IsBool()) {
 		return true
@@ -158,7 +219,7 @@ func (jo *JsonData) validPathCheck(pathArr []string, node *JsonNode) bool {
 			if n < 0 || n >= node.Len() {
 				return false
 			}
-			nNode := node.NodeAt(n)
+			nNode := node.GetNodeAt(n)
 			nPathArr := pathArr[1:]
 			return jo.validPathCheck(nPathArr, nNode)
 		}
@@ -185,6 +246,7 @@ func (jo *JsonData) validPathCheck(pathArr []string, node *JsonNode) bool {
 	return false
 }
 
+// Get will retrieve the json node indicated by a path
 func (jo *JsonData) Get(path string) *JsonNode {
 	if len(path) == 0 {
 		return jo.GetRootNode()
@@ -193,6 +255,7 @@ func (jo *JsonData) Get(path string) *JsonNode {
 	return jo.getByPath(pathArr, jo.GetRootNode())
 }
 
+// getByPath is recursion function to traverse the json tree for retrieving node at specified path
 func (jo *JsonData) getByPath(pathArr []string, node *JsonNode) *JsonNode {
 	if len(pathArr) == 0 && (node.IsString() || node.IsInt() || node.IsFloat() || node.IsBool()) {
 		return node
@@ -214,7 +277,7 @@ func (jo *JsonData) getByPath(pathArr []string, node *JsonNode) *JsonNode {
 			if n < 0 || n >= node.Len() {
 				panic("Not a valid path - array offset < 0 or >= length")
 			}
-			nNode := node.NodeAt(n)
+			nNode := node.GetNodeAt(n)
 			nPathArr := pathArr[1:]
 			return jo.getByPath(nPathArr, nNode)
 		}
@@ -241,6 +304,7 @@ func (jo *JsonData) getByPath(pathArr []string, node *JsonNode) *JsonNode {
 	panic("Not a valid path")
 }
 
+// GetString will get the string value from a json indicated by specified path. Error returned if path is not valid.
 func (n *JsonData) GetString(path string) (string, error) {
 	b, err := n.IsString(path)
 	if err != nil {
@@ -253,6 +317,13 @@ func (n *JsonData) GetString(path string) (string, error) {
 	return node.GetString(), nil
 }
 
+// SetString will set the node at specified path with provided string value
+func (n *JsonData) SetString(path, value string) error {
+	// Todo Implement this
+	return fmt.Errorf("not yet implemented")
+}
+
+// GetBool will get the bool value from a json indicated by specified path. Error returned if path is not valid.
 func (n *JsonData) GetBool(path string) (bool, error) {
 	b, err := n.IsBool(path)
 	if err != nil {
@@ -265,6 +336,13 @@ func (n *JsonData) GetBool(path string) (bool, error) {
 	return node.GetBool(), nil
 }
 
+// SetBool will set the node at specified path with provided bool value
+func (n *JsonData) SetBool(path string, value bool) error {
+	// Todo Implement this
+	return fmt.Errorf("not yet implemented")
+}
+
+// GetFloat will get the float value from a json indicated by specified path. Error returned if path is not valid.
 func (n *JsonData) GetFloat(path string) (float64, error) {
 	b, err := n.IsFloat(path)
 	if err != nil {
@@ -277,6 +355,13 @@ func (n *JsonData) GetFloat(path string) (float64, error) {
 	return node.GetFloat(), nil
 }
 
+// SetFloat will set the node at specified path with provided float value
+func (n *JsonData) SetFloat(path string, value float64) error {
+	// Todo Implement this
+	return fmt.Errorf("not yet implemented")
+}
+
+// GetInt will get the int value from a json indicated by specified path. Error returned if path is not valid.
 func (n *JsonData) GetInt(path string) (int, error) {
 	b, err := n.IsInt(path)
 	if err != nil {
@@ -289,6 +374,13 @@ func (n *JsonData) GetInt(path string) (int, error) {
 	return node.GetInt(), nil
 }
 
+// SetInt will set the node at specified path with provided int value
+func (n *JsonData) SetInt(path string, value int) error {
+	// Todo Implement this
+	return fmt.Errorf("not yet implemented")
+}
+
+// IsArray will check if the node indicated by specified path is an Array node
 func (n *JsonData) IsArray(path string) (bool, error) {
 	if !n.IsValidPath(path) {
 		return false, fmt.Errorf("%s is not a valid path", path)
@@ -296,6 +388,7 @@ func (n *JsonData) IsArray(path string) (bool, error) {
 	return n.Get(path).IsArray(), nil
 }
 
+// IsMap will check if the node indicated by specified path is a map node
 func (n *JsonData) IsMap(path string) (bool, error) {
 	if !n.IsValidPath(path) {
 		return false, fmt.Errorf("%s is not a valid path", path)
@@ -303,6 +396,7 @@ func (n *JsonData) IsMap(path string) (bool, error) {
 	return n.Get(path).IsMap(), nil
 }
 
+// IsString will check if the node indicated by specified path is a string node
 func (n *JsonData) IsString(path string) (bool, error) {
 	if !n.IsValidPath(path) {
 		return false, fmt.Errorf("%s is not a valid path", path)
@@ -310,6 +404,7 @@ func (n *JsonData) IsString(path string) (bool, error) {
 	return n.Get(path).IsString(), nil
 }
 
+// IsBool will check if the node indicated by specified path is a bool node
 func (n *JsonData) IsBool(path string) (bool, error) {
 	if !n.IsValidPath(path) {
 		return false, fmt.Errorf("%s is not a valid path", path)
@@ -317,6 +412,7 @@ func (n *JsonData) IsBool(path string) (bool, error) {
 	return n.Get(path).IsBool(), nil
 }
 
+// IsFloat will check if the node indicated by specified path is a float node
 func (n *JsonData) IsFloat(path string) (bool, error) {
 	if !n.IsValidPath(path) {
 		return false, fmt.Errorf("%s is not a valid path", path)
@@ -324,6 +420,7 @@ func (n *JsonData) IsFloat(path string) (bool, error) {
 	return n.Get(path).IsFloat(), nil
 }
 
+// IsInt will check if the node indicated by specified path is an int node
 func (n *JsonData) IsInt(path string) (bool, error) {
 	if !n.IsValidPath(path) {
 		return false, fmt.Errorf("%s is not a valid path", path)

--- a/pkg/jsontool/JsonDom.go
+++ b/pkg/jsontool/JsonDom.go
@@ -8,49 +8,49 @@ import (
 	"strings"
 )
 
-// NewJsonData will create a new instance of JsonData
-func NewJsonData(jsonData []byte) (*JsonData, error) {
+// NewJSONData will create a new instance of JSONData
+func NewJSONData(jsonData []byte) (*JSONData, error) {
 	var tm interface{}
 
 	err := json.Unmarshal(jsonData, &tm)
 	if err != nil {
 		return nil, err
 	}
-	return &JsonData{jsonRoot: tm}, nil
+	return &JSONData{jsonRoot: tm}, nil
 }
 
-// JsonNode represent a node in JSON Tree
-type JsonNode struct {
+// JSONNode represent a node in JSON Tree
+type JSONNode struct {
 	interf interface{}
 }
 
 // IsArray will check if this node represent an array
-func (n *JsonNode) IsArray() bool {
+func (n *JSONNode) IsArray() bool {
 	return reflect.TypeOf(n.interf).String() == "[]interface {}"
 }
 
 // IsMap will check if this node represent a Map
-func (n *JsonNode) IsMap() bool {
+func (n *JSONNode) IsMap() bool {
 	return reflect.TypeOf(n.interf).String() == "map[string]interface {}"
 }
 
 // IsString check if this node represent a string
-func (n *JsonNode) IsString() bool {
+func (n *JSONNode) IsString() bool {
 	return reflect.TypeOf(n.interf).String() == "string"
 }
 
 // IsBool check if this node represent a boolean
-func (n *JsonNode) IsBool() bool {
+func (n *JSONNode) IsBool() bool {
 	return reflect.TypeOf(n.interf).String() == "bool"
 }
 
 // IsFloat check if this node represent a float
-func (n *JsonNode) IsFloat() bool {
+func (n *JSONNode) IsFloat() bool {
 	return reflect.TypeOf(n.interf).String() == "float64"
 }
 
 // IsInt checks if this node represent an int
-func (n *JsonNode) IsInt() bool {
+func (n *JSONNode) IsInt() bool {
 	if reflect.TypeOf(n.interf).String() == "float64" {
 		v := reflect.ValueOf(n.interf)
 		f := v.Float()
@@ -62,7 +62,7 @@ func (n *JsonNode) IsInt() bool {
 }
 
 // Len return length of element in this array. Will panic if this node is not an array
-func (n *JsonNode) Len() int {
+func (n *JSONNode) Len() int {
 	if !n.IsArray() {
 		panic("Not array")
 	}
@@ -71,16 +71,16 @@ func (n *JsonNode) Len() int {
 }
 
 // GetNodeAt will get the child not on specific index. Will panic if this not is not an array
-func (n *JsonNode) GetNodeAt(index int) *JsonNode {
+func (n *JSONNode) GetNodeAt(index int) *JSONNode {
 	if !n.IsArray() {
 		panic("Not array")
 	}
 	arr := n.interf.([]interface{})
-	return &JsonNode{interf: arr[index]}
+	return &JSONNode{interf: arr[index]}
 }
 
 // HaveKey will check if the map contains specified key. Will panic if this node is not a map
-func (n *JsonNode) HaveKey(key string) bool {
+func (n *JSONNode) HaveKey(key string) bool {
 	if !n.IsMap() {
 		panic("Not map")
 	}
@@ -92,16 +92,16 @@ func (n *JsonNode) HaveKey(key string) bool {
 }
 
 // Get will fetch the child not designated with specified key. Will panic if this node is not a map
-func (n *JsonNode) Get(key string) *JsonNode {
+func (n *JSONNode) Get(key string) *JSONNode {
 	if !n.IsMap() {
 		panic("Not map")
 	}
 	amap := n.interf.(map[string]interface{})
-	return &JsonNode{interf: amap[key]}
+	return &JSONNode{interf: amap[key]}
 }
 
 // Set will set the value of a map designated with specified key. Will panic if this node is not a map
-func (n *JsonNode) Set(key string, node *JsonNode) {
+func (n *JSONNode) Set(key string, node *JSONNode) {
 	if !n.IsMap() {
 		panic("Not map")
 	}
@@ -110,7 +110,7 @@ func (n *JsonNode) Set(key string, node *JsonNode) {
 }
 
 // GetString will get the string value of this node. Will panic if this node is not a string
-func (n *JsonNode) GetString() string {
+func (n *JSONNode) GetString() string {
 	if !n.IsString() {
 		panic("Not string")
 	}
@@ -118,7 +118,7 @@ func (n *JsonNode) GetString() string {
 }
 
 // SetString will set this node value with a string value. Will panic if this node is not a string
-func (n *JsonNode) SetString(val string) {
+func (n *JSONNode) SetString(val string) {
 	if !n.IsString() {
 		panic("Not string")
 	}
@@ -126,7 +126,7 @@ func (n *JsonNode) SetString(val string) {
 }
 
 // GetBool will get the bool value of this node. Will panic if this node is not a boolean
-func (n *JsonNode) GetBool() bool {
+func (n *JSONNode) GetBool() bool {
 	if !n.IsBool() {
 		panic("Not boolean")
 	}
@@ -134,7 +134,7 @@ func (n *JsonNode) GetBool() bool {
 }
 
 // SetBool will set this node value with boolean value, will panic if this node is not a bool
-func (n *JsonNode) SetBool(val bool) {
+func (n *JSONNode) SetBool(val bool) {
 	if !n.IsBool() {
 		panic("Not boolean")
 	}
@@ -142,7 +142,7 @@ func (n *JsonNode) SetBool(val bool) {
 }
 
 // GetFloat will get the float value of this node. Will panic if this node is not a float.
-func (n *JsonNode) GetFloat() float64 {
+func (n *JSONNode) GetFloat() float64 {
 	if !n.IsFloat() {
 		panic("Not float")
 	}
@@ -150,7 +150,7 @@ func (n *JsonNode) GetFloat() float64 {
 }
 
 // SetFloat will set this node value with float value. Will panic if this node is not a float
-func (n *JsonNode) SetFloat(val float64) {
+func (n *JSONNode) SetFloat(val float64) {
 	if !n.IsFloat() {
 		panic("Not float")
 	}
@@ -158,7 +158,7 @@ func (n *JsonNode) SetFloat(val float64) {
 }
 
 // GetInt will get the int value of this node. Will panic if this node is not an int
-func (n *JsonNode) GetInt() int {
+func (n *JSONNode) GetInt() int {
 	if !n.IsInt() {
 		panic("Not int")
 	}
@@ -167,28 +167,28 @@ func (n *JsonNode) GetInt() int {
 }
 
 // SetInt will set this node value with int value. Will panic if this node is not an int
-func (n *JsonNode) SetInt(val int) {
+func (n *JSONNode) SetInt(val int) {
 	if !n.IsInt() {
 		panic("Not int")
 	}
 	n.interf = float64(val)
 }
 
-// JsonData represent a whole Json construct.
-type JsonData struct {
+// JSONData represent a whole Json construct.
+type JSONData struct {
 	jsonRoot interface{}
 }
 
-// GetRootNode will return the root node of this JsonData
-func (jo *JsonData) GetRootNode() *JsonNode {
+// GetRootNode will return the root node of this JSONData
+func (jo *JSONData) GetRootNode() *JSONNode {
 	if jo.jsonRoot == nil {
 		panic(fmt.Sprintf("root node is nil"))
 	}
-	return &JsonNode{interf: jo.jsonRoot}
+	return &JSONNode{interf: jo.jsonRoot}
 }
 
 // IsValidPath will check if the provided path is valid
-func (jo *JsonData) IsValidPath(path string) bool {
+func (jo *JSONData) IsValidPath(path string) bool {
 	if len(path) == 0 {
 		return true
 	}
@@ -198,7 +198,7 @@ func (jo *JsonData) IsValidPath(path string) bool {
 }
 
 // validPathCheck is recursion function to traverse the json tree for checking valid path
-func (jo *JsonData) validPathCheck(pathArr []string, node *JsonNode) bool {
+func (jo *JSONData) validPathCheck(pathArr []string, node *JSONNode) bool {
 	if len(pathArr) == 0 && (node.IsString() || node.IsInt() || node.IsFloat() || node.IsBool()) {
 		return true
 	}
@@ -247,7 +247,7 @@ func (jo *JsonData) validPathCheck(pathArr []string, node *JsonNode) bool {
 }
 
 // Get will retrieve the json node indicated by a path
-func (jo *JsonData) Get(path string) *JsonNode {
+func (jo *JSONData) Get(path string) *JSONNode {
 	if len(path) == 0 {
 		return jo.GetRootNode()
 	}
@@ -256,7 +256,7 @@ func (jo *JsonData) Get(path string) *JsonNode {
 }
 
 // getByPath is recursion function to traverse the json tree for retrieving node at specified path
-func (jo *JsonData) getByPath(pathArr []string, node *JsonNode) *JsonNode {
+func (jo *JSONData) getByPath(pathArr []string, node *JSONNode) *JSONNode {
 	if len(pathArr) == 0 && (node.IsString() || node.IsInt() || node.IsFloat() || node.IsBool()) {
 		return node
 	}
@@ -305,125 +305,125 @@ func (jo *JsonData) getByPath(pathArr []string, node *JsonNode) *JsonNode {
 }
 
 // GetString will get the string value from a json indicated by specified path. Error returned if path is not valid.
-func (n *JsonData) GetString(path string) (string, error) {
-	b, err := n.IsString(path)
+func (jo *JSONData) GetString(path string) (string, error) {
+	b, err := jo.IsString(path)
 	if err != nil {
 		return "", err
 	}
 	if !b {
 		return "", fmt.Errorf("%s is not a string", path)
 	}
-	node := n.Get(path)
+	node := jo.Get(path)
 	return node.GetString(), nil
 }
 
 // SetString will set the node at specified path with provided string value
-func (n *JsonData) SetString(path, value string) error {
+func (jo *JSONData) SetString(path, value string) error {
 	// Todo Implement this
 	return fmt.Errorf("not yet implemented")
 }
 
 // GetBool will get the bool value from a json indicated by specified path. Error returned if path is not valid.
-func (n *JsonData) GetBool(path string) (bool, error) {
-	b, err := n.IsBool(path)
+func (jo *JSONData) GetBool(path string) (bool, error) {
+	b, err := jo.IsBool(path)
 	if err != nil {
 		return false, err
 	}
 	if !b {
 		return false, fmt.Errorf("%s is not a boolean", path)
 	}
-	node := n.Get(path)
+	node := jo.Get(path)
 	return node.GetBool(), nil
 }
 
 // SetBool will set the node at specified path with provided bool value
-func (n *JsonData) SetBool(path string, value bool) error {
+func (jo *JSONData) SetBool(path string, value bool) error {
 	// Todo Implement this
 	return fmt.Errorf("not yet implemented")
 }
 
 // GetFloat will get the float value from a json indicated by specified path. Error returned if path is not valid.
-func (n *JsonData) GetFloat(path string) (float64, error) {
-	b, err := n.IsFloat(path)
+func (jo *JSONData) GetFloat(path string) (float64, error) {
+	b, err := jo.IsFloat(path)
 	if err != nil {
 		return 0, err
 	}
 	if !b {
 		return 0, fmt.Errorf("%s is not a float", path)
 	}
-	node := n.Get(path)
+	node := jo.Get(path)
 	return node.GetFloat(), nil
 }
 
 // SetFloat will set the node at specified path with provided float value
-func (n *JsonData) SetFloat(path string, value float64) error {
+func (jo *JSONData) SetFloat(path string, value float64) error {
 	// Todo Implement this
 	return fmt.Errorf("not yet implemented")
 }
 
 // GetInt will get the int value from a json indicated by specified path. Error returned if path is not valid.
-func (n *JsonData) GetInt(path string) (int, error) {
-	b, err := n.IsInt(path)
+func (jo *JSONData) GetInt(path string) (int, error) {
+	b, err := jo.IsInt(path)
 	if err != nil {
 		return 0, err
 	}
 	if !b {
 		return 0, fmt.Errorf("%s is not an int", path)
 	}
-	node := n.Get(path)
+	node := jo.Get(path)
 	return node.GetInt(), nil
 }
 
 // SetInt will set the node at specified path with provided int value
-func (n *JsonData) SetInt(path string, value int) error {
+func (jo *JSONData) SetInt(path string, value int) error {
 	// Todo Implement this
 	return fmt.Errorf("not yet implemented")
 }
 
 // IsArray will check if the node indicated by specified path is an Array node
-func (n *JsonData) IsArray(path string) (bool, error) {
-	if !n.IsValidPath(path) {
+func (jo *JSONData) IsArray(path string) (bool, error) {
+	if !jo.IsValidPath(path) {
 		return false, fmt.Errorf("%s is not a valid path", path)
 	}
-	return n.Get(path).IsArray(), nil
+	return jo.Get(path).IsArray(), nil
 }
 
 // IsMap will check if the node indicated by specified path is a map node
-func (n *JsonData) IsMap(path string) (bool, error) {
-	if !n.IsValidPath(path) {
+func (jo *JSONData) IsMap(path string) (bool, error) {
+	if !jo.IsValidPath(path) {
 		return false, fmt.Errorf("%s is not a valid path", path)
 	}
-	return n.Get(path).IsMap(), nil
+	return jo.Get(path).IsMap(), nil
 }
 
 // IsString will check if the node indicated by specified path is a string node
-func (n *JsonData) IsString(path string) (bool, error) {
-	if !n.IsValidPath(path) {
+func (jo *JSONData) IsString(path string) (bool, error) {
+	if !jo.IsValidPath(path) {
 		return false, fmt.Errorf("%s is not a valid path", path)
 	}
-	return n.Get(path).IsString(), nil
+	return jo.Get(path).IsString(), nil
 }
 
 // IsBool will check if the node indicated by specified path is a bool node
-func (n *JsonData) IsBool(path string) (bool, error) {
-	if !n.IsValidPath(path) {
+func (jo *JSONData) IsBool(path string) (bool, error) {
+	if !jo.IsValidPath(path) {
 		return false, fmt.Errorf("%s is not a valid path", path)
 	}
-	return n.Get(path).IsBool(), nil
+	return jo.Get(path).IsBool(), nil
 }
 
 // IsFloat will check if the node indicated by specified path is a float node
-func (n *JsonData) IsFloat(path string) (bool, error) {
-	if !n.IsValidPath(path) {
+func (jo *JSONData) IsFloat(path string) (bool, error) {
+	if !jo.IsValidPath(path) {
 		return false, fmt.Errorf("%s is not a valid path", path)
 	}
-	return n.Get(path).IsFloat(), nil
+	return jo.Get(path).IsFloat(), nil
 }
 
 // IsInt will check if the node indicated by specified path is an int node
-func (n *JsonData) IsInt(path string) (bool, error) {
-	if !n.IsValidPath(path) {
+func (jo *JSONData) IsInt(path string) (bool, error) {
+	if !jo.IsValidPath(path) {
 		return false, fmt.Errorf("%s is not a valid path", path)
 	}
-	return n.Get(path).IsInt(), nil
+	return jo.Get(path).IsInt(), nil
 }

--- a/pkg/jsontool/JsonDom.go
+++ b/pkg/jsontool/JsonDom.go
@@ -1,0 +1,140 @@
+package jsontool
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+func NewJsonData(jsonData []byte) (*JsonData, error) {
+	var tm interface{}
+
+	err := json.Unmarshal(jsonData, &tm)
+	if err != nil {
+		return nil, err
+	}
+	return &JsonData{jsonRoot: tm}, nil
+}
+
+type JsonNode struct {
+	interf interface{}
+}
+
+func (n *JsonNode) IsArray() bool {
+	return reflect.TypeOf(n.interf).String() == "[]interface {}"
+}
+
+func (n *JsonNode) IsMap() bool {
+	return reflect.TypeOf(n.interf).String() == "map[string]interface {}"
+}
+
+func (n *JsonNode) IsString() bool {
+	return reflect.TypeOf(n.interf).String() == "string"
+}
+
+func (n *JsonNode) IsBool() bool {
+	return reflect.TypeOf(n.interf).String() == "bool"
+}
+
+func (n *JsonNode) IsFloat() bool {
+	return reflect.TypeOf(n.interf).String() == "float64"
+}
+
+func (n *JsonNode) IsInt() bool {
+	if reflect.TypeOf(n.interf).String() == "float64" {
+		v := reflect.ValueOf(n.interf)
+		f := v.Float()
+		i := int64(f)
+		f2 := float64(i)
+		return f == f2
+	}
+	return true
+}
+
+func (n *JsonNode) Len() int {
+	if !n.IsArray() {
+		panic("Not array")
+	}
+	arr := n.interf.([]interface{})
+	return len(arr)
+}
+
+func (n *JsonNode) NodeAt(index int) *JsonNode {
+	if !n.IsArray() {
+		panic("Not array")
+	}
+	arr := n.interf.([]interface{})
+	return &JsonNode{interf: arr[index]}
+}
+
+func (n *JsonNode) HaveKey(key string) bool {
+	if !n.IsMap() {
+		panic("Not map")
+	}
+	amap := n.interf.(map[string]interface{})
+	if _, ok := amap[key]; ok {
+		return ok
+	}
+	return false
+}
+
+func (n *JsonNode) Get(key string) *JsonNode {
+	if !n.IsMap() {
+		panic("Not map")
+	}
+	amap := n.interf.(map[string]interface{})
+	return &JsonNode{interf: amap[key]}
+}
+
+func (n *JsonNode) GetString() string {
+	if !n.IsString() {
+		panic("Not string")
+	}
+	return n.interf.(string)
+}
+
+func (n *JsonNode) GetBool() bool {
+	if !n.IsBool() {
+		panic("Not boolean")
+	}
+	return n.interf.(bool)
+}
+
+func (n *JsonNode) GetFloat() float64 {
+	if !n.IsFloat() {
+		panic("Not float")
+	}
+	return n.interf.(float64)
+}
+
+func (n *JsonNode) GetInt() int {
+	if !n.IsInt() {
+		panic("Not int")
+	}
+	fl := n.interf.(float64)
+	return int(fl)
+}
+
+type JsonData struct {
+	jsonRoot interface{}
+}
+
+func (jo *JsonData) GetRootNode() *JsonNode {
+	if jo.jsonRoot == nil {
+		panic(fmt.Sprintf("root node is nil"))
+	}
+	return &JsonNode{interf: jo.jsonRoot}
+}
+
+func (jo *JsonData) IsValidPath(path string) bool {
+	if len(path) == 0 {
+		return true
+	}
+	return false
+	// TODO resolve this
+}
+
+func (jo *JsonData) Get(path string) *JsonNode {
+	return nil
+	// TODO resolve this
+}

--- a/pkg/jsontool/JsonDom_test.go
+++ b/pkg/jsontool/JsonDom_test.go
@@ -1,0 +1,173 @@
+package jsontool
+
+import (
+	"reflect"
+	"testing"
+)
+
+var (
+	JsonText = [...]string{
+		`{
+	"stringAttr":"stringVal", 
+	"intAttr":123, 
+	"floatAttr":123.456, 
+	"boolAttr": true, 
+	"arrayAttr": [1,2,3,4], 
+	"objAttr": {
+		"attr1":1234, 
+		"attr2": "string"
+	}}`,
+		`[1,2,3,4]`,
+		`["1","2","3","4"]`,
+		`["1", 2, 3.4, true]`,
+		`{}`,
+		`[]`,
+		`12345`,
+		`123.45`,
+		`"123"`,
+		`true`,
+		`false`,
+	}
+
+	JsonType = [...]string{
+		"obj",
+		"arr",
+		"arr",
+		"arr",
+		"obj",
+		"arr",
+		"int",
+		"float",
+		"string",
+		"bool",
+		"bool",
+	}
+
+	bigJson = `
+{
+	"fullname" : "Bruce Wayne",
+	"address" : {
+		"street1" : "Super Mansion",
+		"street2" : "DC Commic Rd",
+		"zip" : 84893,
+		"city" : "Metro City"
+	},
+	"age" : 35,
+	"height" : 5.23,
+	"gender" : "male",
+	"active" : true,
+	"friends" : [
+		{
+			"fullname" : "Peter Parker",
+			"address" : {
+				"street1" : "Other Super Mansion",
+				"street2" : "DC Commic Rd",
+				"zip" : 84893,
+				"city" : "Metro City"
+			},
+			"age" : 32,
+			"height" : 5.42,
+			"gender" : "male",
+			"active" : true
+		}, {
+			"fullname" : "Lara Croft",
+			"address" : {
+				"street1" : "Lilly Bulevard",
+				"street2" : "Clear Hill",
+				"zip" : 65223,
+				"city" : "Fiction Mount"
+			},
+			"age" : 28,
+			"height" : 5.5,
+			"gender" : "female",
+			"active" : false
+		}
+	]
+}
+`
+)
+
+func TestNewJsonObject(t *testing.T) {
+	for i, v := range JsonText {
+		jobj, err := NewJsonData([]byte(v))
+		if err != nil {
+			t.Logf("Error : %d - %s. Got %s", i, v, err.Error())
+			t.Fail()
+		} else {
+			typ := reflect.TypeOf(jobj.jsonRoot)
+			t.Logf("Data : %d - %s. Type is : %s ", i, v, typ.String())
+			node := jobj.GetRootNode()
+			switch JsonType[i] {
+			case "obj":
+				if !node.IsMap() {
+					t.Logf("Error : %d - %s. Is not map", i, v)
+					t.Fail()
+				}
+			case "arr":
+				if !node.IsArray() {
+					t.Logf("Error : %d - %s. Is not array", i, v)
+					t.Fail()
+				}
+			case "int":
+				if !node.IsInt() {
+					t.Logf("Error : %d - %s. Is not int", i, v)
+					t.Fail()
+				}
+			case "float":
+				if !node.IsFloat() {
+					t.Logf("Error : %d - %s. Is not float", i, v)
+					t.Fail()
+				}
+				if node.IsInt() {
+					t.Logf("Error : %d - %s. Is supposed not to be int", i, v)
+					t.Fail()
+				}
+			case "string":
+				if !node.IsString() {
+					t.Logf("Error : %d - %s. Is not string", i, v)
+					t.Fail()
+				}
+			case "bool":
+				if !node.IsBool() {
+					t.Logf("Error : %d - %s. Is not bool", i, v)
+					t.Fail()
+				}
+			default:
+				t.Logf("Error : %d - %s. Invalid test data type", i, v)
+				t.Fail()
+			}
+		}
+	}
+}
+
+func TestJsonNodeOperations(t *testing.T) {
+	jdata, err := NewJsonData([]byte(bigJson))
+	if err != nil {
+		t.Logf("Got error %s", err.Error())
+		t.FailNow()
+	}
+	if jdata.GetRootNode().Get("fullname").GetString() != "Bruce Wayne" {
+		t.Logf("fail validate full name")
+		t.Fail()
+	}
+	if jdata.GetRootNode().Get("age").GetInt() != 35 {
+		t.Logf("fail validate age")
+		t.Fail()
+	}
+	if jdata.GetRootNode().Get("address").Get("street1").GetString() != "Super Mansion" {
+		t.Logf("fail validate address.street1")
+		t.Fail()
+	}
+	if !jdata.GetRootNode().Get("friends").IsArray() {
+		t.Logf("fail validate friends as array")
+		t.Fail()
+	}
+	if !jdata.GetRootNode().Get("friends").NodeAt(1).Get("fullname").IsString() {
+		t.Logf("fail validate friends[1].fullname type")
+		t.Fail()
+	}
+	if jdata.GetRootNode().Get("friends").NodeAt(1).Get("fullname").GetString() != "Lara Croft" {
+		t.Logf("fail validate friends[1].fullname value")
+		t.Fail()
+	}
+}

--- a/pkg/jsontool/JsonDom_test.go
+++ b/pkg/jsontool/JsonDom_test.go
@@ -146,27 +146,81 @@ func TestJsonNodeOperations(t *testing.T) {
 		t.Logf("Got error %s", err.Error())
 		t.FailNow()
 	}
+
 	if jdata.GetRootNode().Get("fullname").GetString() != "Bruce Wayne" {
 		t.Logf("fail validate full name")
 		t.Fail()
 	}
+	s, err := jdata.GetString("fullname")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if s != "Bruce Wayne" {
+		t.Logf("fail validate full name")
+		t.Fail()
+	}
+
 	if jdata.GetRootNode().Get("age").GetInt() != 35 {
 		t.Logf("fail validate age")
 		t.Fail()
 	}
+	i, err := jdata.GetInt("age")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if i != 35 {
+		t.Logf("fail validate age")
+		t.Fail()
+	}
+
 	if jdata.GetRootNode().Get("address").Get("street1").GetString() != "Super Mansion" {
 		t.Logf("fail validate address.street1")
 		t.Fail()
 	}
+	s, err = jdata.GetString("address.street1")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if s != "Super Mansion" {
+		t.Logf("fail validate address.street1")
+		t.Fail()
+	}
+
 	if !jdata.GetRootNode().Get("friends").IsArray() {
 		t.Logf("fail validate friends as array")
 		t.Fail()
 	}
+	b, err := jdata.IsArray("friends")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if !b {
+		t.Logf("fail validate friends as array")
+		t.Fail()
+	}
+
 	if !jdata.GetRootNode().Get("friends").NodeAt(1).Get("fullname").IsString() {
 		t.Logf("fail validate friends[1].fullname type")
 		t.Fail()
 	}
+	b, err = jdata.IsString("friends[1].fullname")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if !b {
+		t.Logf("fail validate friends[1].fullname type")
+		t.Fail()
+	}
+
 	if jdata.GetRootNode().Get("friends").NodeAt(1).Get("fullname").GetString() != "Lara Croft" {
+		t.Logf("fail validate friends[1].fullname value")
+		t.Fail()
+	}
+	str, err := jdata.GetString("friends[1].fullname")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if str != "Lara Croft" {
 		t.Logf("fail validate friends[1].fullname value")
 		t.Fail()
 	}

--- a/pkg/jsontool/JsonDom_test.go
+++ b/pkg/jsontool/JsonDom_test.go
@@ -177,6 +177,16 @@ func TestJsonNodeOperations(t *testing.T) {
 		t.Logf("fail validate address.street1")
 		t.Fail()
 	}
+
+	m, err := jdata.IsMap("address")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if !m {
+		t.Logf("address is a map")
+		t.Fail()
+	}
+
 	s, err = jdata.GetString("address.street1")
 	if err != nil {
 		t.Errorf(err.Error())
@@ -199,7 +209,7 @@ func TestJsonNodeOperations(t *testing.T) {
 		t.Fail()
 	}
 
-	if !jdata.GetRootNode().Get("friends").NodeAt(1).Get("fullname").IsString() {
+	if !jdata.GetRootNode().Get("friends").GetNodeAt(1).Get("fullname").IsString() {
 		t.Logf("fail validate friends[1].fullname type")
 		t.Fail()
 	}
@@ -212,7 +222,7 @@ func TestJsonNodeOperations(t *testing.T) {
 		t.Fail()
 	}
 
-	if jdata.GetRootNode().Get("friends").NodeAt(1).Get("fullname").GetString() != "Lara Croft" {
+	if jdata.GetRootNode().Get("friends").GetNodeAt(1).Get("fullname").GetString() != "Lara Croft" {
 		t.Logf("fail validate friends[1].fullname value")
 		t.Fail()
 	}

--- a/pkg/jsontool/JsonDom_test.go
+++ b/pkg/jsontool/JsonDom_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	JsonText = [...]string{
+	JSONText = [...]string{
 		`{
 	"stringAttr":"stringVal", 
 	"intAttr":123, 
@@ -29,7 +29,7 @@ var (
 		`false`,
 	}
 
-	JsonType = [...]string{
+	JSONType = [...]string{
 		"obj",
 		"arr",
 		"arr",
@@ -43,7 +43,7 @@ var (
 		"bool",
 	}
 
-	bigJson = `
+	bigJSON = `
 {
 	"fullname" : "Bruce Wayne",
 	"address" : {
@@ -88,8 +88,8 @@ var (
 )
 
 func TestNewJsonObject(t *testing.T) {
-	for i, v := range JsonText {
-		jobj, err := NewJsonData([]byte(v))
+	for i, v := range JSONText {
+		jobj, err := NewJSONData([]byte(v))
 		if err != nil {
 			t.Logf("Error : %d - %s. Got %s", i, v, err.Error())
 			t.Fail()
@@ -97,7 +97,7 @@ func TestNewJsonObject(t *testing.T) {
 			typ := reflect.TypeOf(jobj.jsonRoot)
 			t.Logf("Data : %d - %s. Type is : %s ", i, v, typ.String())
 			node := jobj.GetRootNode()
-			switch JsonType[i] {
+			switch JSONType[i] {
 			case "obj":
 				if !node.IsMap() {
 					t.Logf("Error : %d - %s. Is not map", i, v)
@@ -141,7 +141,7 @@ func TestNewJsonObject(t *testing.T) {
 }
 
 func TestJsonNodeOperations(t *testing.T) {
-	jdata, err := NewJsonData([]byte(bigJson))
+	jdata, err := NewJSONData([]byte(bigJSON))
 	if err != nil {
 		t.Logf("Got error %s", err.Error())
 		t.FailNow()
@@ -237,7 +237,7 @@ func TestJsonNodeOperations(t *testing.T) {
 }
 
 func TestJsonData_IsValidPath(t *testing.T) {
-	jdata, err := NewJsonData([]byte(bigJson))
+	jdata, err := NewJSONData([]byte(bigJSON))
 	if err != nil {
 		t.Logf("Got error %s", err.Error())
 		t.FailNow()

--- a/pkg/jsontool/JsonDom_test.go
+++ b/pkg/jsontool/JsonDom_test.go
@@ -171,3 +171,67 @@ func TestJsonNodeOperations(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestJsonData_IsValidPath(t *testing.T) {
+	jdata, err := NewJsonData([]byte(bigJson))
+	if err != nil {
+		t.Logf("Got error %s", err.Error())
+		t.FailNow()
+	}
+	if !jdata.IsValidPath("fullname") {
+		t.Logf("fullname is a valid path")
+		t.Fail()
+	}
+	if jdata.IsValidPath("fullname.") {
+		t.Logf("fullname. is not a valid path")
+		t.Fail()
+	}
+	if jdata.IsValidPath("fullname.abc") {
+		t.Logf("fullname.abc is not a valid path")
+		t.Fail()
+	}
+	if jdata.IsValidPath("fullname[]") {
+		t.Logf("fullname[] is not a valid path")
+		t.Fail()
+	}
+	if jdata.IsValidPath("abc") {
+		t.Logf("abs is not a valid path")
+		t.Fail()
+	}
+	if !jdata.IsValidPath("") {
+		t.Logf("empty string is a valid path")
+		t.Fail()
+	}
+	if !jdata.IsValidPath("address.street1") {
+		t.Logf("\"address.street1\" is a valid path")
+		t.Fail()
+	}
+	if jdata.IsValidPath("address.street5") {
+		t.Logf("\"address.street5\" is NOT a valid path")
+		t.Fail()
+	}
+	if !jdata.IsValidPath("friends") {
+		t.Logf("\"friends\" is a valid path")
+		t.Fail()
+	}
+	if !jdata.IsValidPath("friends[1]") {
+		t.Logf("\"friends[1]\" is a valid path")
+		t.Fail()
+	}
+	if jdata.IsValidPath("friends[]") {
+		t.Logf("\"friends[]\" is NOT a valid path")
+		t.Fail()
+	}
+	if jdata.IsValidPath("friends[10]") {
+		t.Logf("\"friends[10]\" is NOT a valid path")
+		t.Fail()
+	}
+	if !jdata.IsValidPath("friends[1].address.street1") {
+		t.Logf("\"friends[1].address.street1\" is a valid path")
+		t.Fail()
+	}
+	if jdata.IsValidPath("friends[1].abc.street1") {
+		t.Logf("\"friends[1].abc.street1\" is a valid path")
+		t.Fail()
+	}
+}


### PR DESCRIPTION
The issue Supporting concurrent threads executing rules #60 says a valid point.
We need to be able to execute grule `KnowledgeBase` in a thread save manner. 

Currently, `KnowledgeBase` retain the state of values as the rule execution progresses.  This makes it illogical to use the same `KnowledgeBase` across multiple thread. Thus we need a complete separate instance of `KnowledgeBase` and the only way to do this is by **rebuilding** the `KnowledgeBase` using `RuleBuilder` each and every time which is heavy and inefficient.

This pull request introduces `KnowledgeLibrary` where we build all of our rules into it, and have them identified by it's `name` and `version`. 

```go
	lib := ast.NewKnowledgeLibrary()
	rb := builder.NewRuleBuilder(lib)
	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(Rule4)))
```

And later, when we want to execute on of the `KnowledgeBase` inside the `KnowledgeLibrary` we can simple call (in each running thread)

```go
	kb := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
```

And then execute (in that thread)

```go
	eng := &engine.GruleEngine{MaxCycle: 3}
	err := eng.Execute(dataContext, kb)
```

Also notice that `WorkingMemory` is now part of the `KnowledgeBase` and managed internally.