### PR TITLE
Add support for JSON format rules

### DIFF
--- a/docs/GRL_JSON_en.md
+++ b/docs/GRL_JSON_en.md
@@ -1,0 +1,209 @@
+# Grule JSON Format
+
+Grule rules can be represented in JSON form and translated for use by the rule engine into standard Grule syntax. The design of the JSON format is intended to offer a high level of flexability to suite the needs of the user.
+
+The basic structure of a JSON rule is as follows:
+```json
+{
+    "name": "SpeedUp",
+    "desc": "When testcar is speeding up we keep increase the speed.",
+    "salience": 10,
+    "when": ...,
+    "then": [
+        ...
+    ]
+}
+```
+
+## Elements
+
+| Name       | Description                                                                                                             |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `name`     | The name of the rule. This field is required.                                                                           |
+| `desc`     | The description for the rule. If not set the rules description will be set to `""`                                      |
+| `salience` | The salience value for the rule. If this value is not set the saliance will default to 0                                |
+| `when`     | The when conndition for the rule. This field can either be a plain string value or a condition object (described below) |
+| `then`           | An array of then actions for the rule. Each aray element can be a plain string or a then object (described below)                                                                                                                        |
+
+## Condition Object
+
+In order to provide a great deal of flexability, the when condition of a rule can be broken down into individual components. This is particularly useful for structuring larger rules and supporting GUI applications used for rule editing and analysis.
+
+Condition objects are parsed recursively, meaning that objects can be nested arbitarily to support even the most complex rules. Any time a condition object is expected by the parser, the user can choose to instead provide a constant string or numeric value which will be interpreted by the parser as raw input to be echoed into the output rule.
+
+Each condition object takes the following format:
+```json
+{"operator":[x, y...]}
+```
+where operator is one of the operators described below and x and y two or more condition objects or constants.
+
+### Operators
+
+| Operator  | Description       |
+| --------- | ----------------- |
+| `"and"`   | GRL && operator   |
+| `"or"`    | GRL \|\| operator |
+| `"eq"`    | GRL == operator   |
+| `"not"`   | GRL != operator   |
+| `"gt"`    | GRL > operator    |
+| `"gte"`   | GRL >= operator   |
+| `"lt"`    | GRL < operator    |
+| `"lte"`   | GRL <= operaotr   |
+| `"bor"`   | GRL \| operator   |
+| `"band"`  | GRL & operator    |
+| `"plus"`  | GRL + operator    |
+| `"minus"` | GRL - operator    |
+| `"div"`   | GRL / operator    |
+| `"mul"`   | GRL * operator    |
+| `"mod"`   | GRL % operator    |
+
+### Special Operators
+
+The following operators have slightly different behaviours than the standard operators.
+
+| Operator  | Description                                                                                                                                                                                                                |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"set"`   | GRL = operator. This operator will set the value of the first operand to the output of the second. This can only be used in the `then` section of the rule.                                                                |
+| `"call"`  | GRL function call. The operator will call the funtion name specified in the first operand. If more then one operand is specififed, the subsequent operands are interpreted as arguments to be passed to the funciton call. |
+| `"obj"`   | Explicitly identifies a GRL object. Unkline other operators, this object takes the form of a simple key/value pair. For example: `{"obj": "TestCar.Speed"}`                                                                |
+| `"const"` | Explicitly identified a GRL constant. This opertor takes the same form as the `obj` operator                                                                                                                               |
+
+### Supported Constants
+
+The following constant types are supported:
+
+| Type      | Example                     |
+| --------- | --------------------------- |
+| `string`  | `{"const": "String Value"}` |
+| `integer` | `{"const": 123}`            |
+| `float`   | `{"const": 1.29738}`        |
+| `bool`    | `{"const": true}`           |
+
+
+## Then Actions
+
+The `then` actions are formed in the same way as the condition objects. The primary difference is that the root element for each then condition should be either a `set` or `call` operator.
+
+# Example
+
+To demonstrate the JSON representation capabilities, the following example rule is to be converted to JSON syntax:
+
+```
+rule SpeedUp "When testcar is speeding up we keep increase the speed." salience 10 {
+    when
+        TestCar.SpeedUp == true && TestCar.Speed < TestCar.MaxSpeed
+    then
+        TestCar.Speed = TestCar.Speed + TestCar.SpeedIncrement;
+        DistanceRecord.TotalDistance = DistanceRecord.TotalDistance + TestCar.Speed;
+        Log("Speed increased");
+}
+```
+
+## Basic Representation
+
+The most basic representation of this rule in JSON is as follows:
+```json
+{
+    "name": "SpeedUp",
+    "desc": "When testcar is speeding up we keep increase the speed.",
+    "salience": 10,
+    "when": "TestCar.SpeedUp == true && TestCar.Speed < TestCar.MaxSpeed",
+    "then": [
+        "TestCar.Speed = TestCar.Speed + TestCar.SpeedIncrement",
+        "DistanceRecord.TotalDistance = DistanceRecord.TotalDistance + TestCar.Speed",
+        "Log(\"Speed increased\")"
+    ]
+}
+```
+
+This example presents the when and then conditions as raw input objects. This gives the greatest level of control over the output rule. In most cases the translator will output a rule which is an exact match to the original representaion, however in some cases the translator may insert brackets around expressions where it is not required depending on operator presedence. This should not affect the logical meaning of the rule.
+
+## Expanded Representation
+
+The above rule can also be represented in a more explicit format by breaking down the when and then conditions to full object representation:
+```json
+{
+    "name": "SpeedUp",
+    "desc": "When testcar is speeding up we keep increase the speed.",
+    "salience": 10,
+    "when": {
+       "and": [
+           {"eq": ["TestCar.SpeedUp", true]},
+           {"lt": ["TestCar.Speed", "TestCar.MaxSpeed"]}
+       ]
+    },
+    "then": [
+        {"set": ["TestCar.Speed", {"plus": ["TestCar.Speed", "TestCar.SpeedIncrement"]}]},
+        {"set": ["DistanceRecord.TotalDistance", {"plus": ["DistanceRecord.TotalDistance", "TestCar.Speed"]}]},
+        {"call": ["Log", {"const": "Speed increased"}]}
+    ]
+}
+```
+
+The translator will interpret the above rule and produce the same output as the example rule. This rule is much more verbose and can be easily parsed and formated for display or analysis purposes.
+
+## Implicit Representation and String Escaping
+
+Despite being more verbose, the rule above still represent objects and boolean constants implictly. It is not necessary to wrap each object and constant inside of a `const` or `obj` operator because the translator will implicitly interpret the type of input. However, in some cases it can be advantagious to use the `const` or `obj` wrappers, the most notable of which is to enforce escaping rules on string constants that would not be applied to an implicilt string.
+
+An example of string escaping behaviour shown in the rule above is in the `call` then action. A string is being passed as an argument to the function so in order to pass the argument as a raw object it is necessary for the user to wrap the constant in double quotes and escape them manually:
+`{"call": ["Log", "\"Speed increased\""]}`
+
+While this gives the correct output, it somewhat obfuscates the rule by making it unclear which level of escaping is applied to the output.
+
+If the escaping of the string is done incorrectly, the translator will generate an invalid rule output. In order to prevent this kind of error, it is preferable to wrap the constant in a `const` operator:
+`{"call": ["Log", {"const": "Speed increased"}]}`
+
+I this case, the translator will escape the constant string appropriately and ouput the constant correctly to the output rule.
+
+## Verbose Representation
+
+The most verbose possible version of the example rule in JSON syntax is as follows. Note that the additional `obj` and `const` operators here are completely unnecessary but can be useful for rendering engines or tools designed to edit or analyse rules in a visual form.
+
+```json
+{
+    "name": "SpeedUp",
+    "desc": "When testcar is speeding up we keep increase the speed.",
+    "salience": 10,
+    "when": {
+       "and": [
+           {"eq": [{"obj": "TestCar.SpeedUp"}, {"const": true}]},
+           {"lt": [{"obj": "TestCar.Speed"}, {"obj": "TestCar.MaxSpeed"}]}
+       ]
+    },
+    "then": [
+        {"set": [{"obj": "TestCar.Speed"}, {"plus": [{"obj": "TestCar.Speed"}, {"obj": "TestCar.SpeedIncrement"}]}]},
+        {"set": [{"obj": "DistanceRecord.TotalDistance"}, {"plus": [{"obj": "DistanceRecord.TotalDistance"}, {"obj": "TestCar.Speed"}]}]},
+        {"call": ["Log", {"const": "Speed increased"}]}
+    ]
+}
+```
+
+# Loading JSON Rules
+
+JSON rules can be loaded from an underlying Resource or ResourceBundle provider using the functions `NewJSONResourceFromResource` and `NewJSONResourceBundleFromBundle` respectively. When the `Load()` function is called the underlying Resource is loaded and the rules are translated from JSON syntax to standard GRL syntax. As a result the translation functions can very easily be integrated into existing code.
+
+```go
+f, err := os.Open("rules.json")
+if err != nil {
+    panic(err)
+}
+underlying := pkg.NewReaderResource(f)
+resource := pkg.NewJSONResourceFromResource(underlying)
+...
+```
+
+It is also possible to parse a byte array containing JSON rules directly into a GRL syntax ruleset by calling the `ParseJSONRuleset` function.
+
+```go
+jsonData, err := ioutil.ReadFile("rules.json")
+if err != nil {
+    panic(err)
+}
+ruleset, err := pkg.ParseJSONRuleset(jsonData)
+if err != nil {
+    panic(err)
+}
+fmt.Println("Parsed ruleset: ")
+fmt.Println(ruleset)
+```

--- a/pkg/JsonResource.go
+++ b/pkg/JsonResource.go
@@ -1,0 +1,353 @@
+package pkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// GruleJSON represents a rule in JSON format
+type GruleJSON struct {
+	Name        string        `json:"name"`
+	Description string        `json:"desc"`
+	Salience    int           `json:"salience"`
+	When        interface{}   `json:"when"`
+	Then        []interface{} `json:"then"`
+}
+
+// JSONResource will parse rules in JSON fromat from underlying resource provider.
+type JSONResource struct {
+	subRes Resource
+}
+
+// JSONResourceBundle will parse a set of rules in JSON format from an underlying bundle resource provider.
+type JSONResourceBundle struct {
+	subRes ResouceBundle
+}
+
+// NewJSONResourceFromResource innstantiates a new JSON resource parser from an underlying Resource.
+func NewJSONResourceFromResource(res Resource) Resource {
+	if _, ok := res.(*JSONResource); ok {
+		panic("cannot create JSON resource from JSON resource")
+	}
+	return &JSONResource{
+		subRes: res,
+	}
+}
+
+// Load will load the underlying Resource and parse the JSON rules into standard GRule syntax.
+func (jr *JSONResource) Load() ([]byte, error) {
+	var err error
+	var data []byte
+	data, err = jr.subRes.Load()
+	if err != nil {
+		return nil, err
+	}
+	var rs string
+	rs, err = ParseJSONRuleset(data)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(rs), nil
+}
+
+// String will state the resource source.
+func (jr *JSONResource) String() string {
+	return "JSON Resource, underlying resource: " + jr.subRes.String()
+}
+
+// NewJSONResourceBundleFromBundle innstantiates a new bundled JSON resource parser from an underlying ResourceBundle.
+func NewJSONResourceBundleFromBundle(bundle ResouceBundle) ResouceBundle {
+	if _, ok := bundle.(*JSONResourceBundle); ok {
+		panic("cannot create JSON resource bundle from JSON resource bundle")
+	}
+	return &JSONResourceBundle{
+		subRes: bundle,
+	}
+}
+
+// Load will load the underlying ResourceBundle and parse the JSON rules into standard GRule syntax.
+func (jrb *JSONResourceBundle) Load() ([]Resource, error) {
+	ress, err := jrb.subRes.Load()
+	if err != nil {
+		return nil, err
+	}
+	nress := make([]Resource, len(ress))
+	for i := 0; i < len(ress); i++ {
+		nress[i] = NewJSONResourceFromResource(ress[i])
+	}
+	return nress, nil
+}
+
+// MustLoad operates the same as load except it will panic in the event of an error.
+func (jrb *JSONResourceBundle) MustLoad() []Resource {
+	ress := jrb.subRes.MustLoad()
+	nress := make([]Resource, len(ress))
+	for i := 0; i < len(ress); i++ {
+		nress[i] = NewJSONResourceFromResource(ress[i])
+	}
+	return nress
+}
+
+// ParseJSONRuleset accepts a byte array containing an array of rules in JSON format to be parsed into GRule syntax.
+func ParseJSONRuleset(data []byte) (rs string, err error) {
+	defer func() {
+		if x := recover(); x != nil {
+			err = fmt.Errorf("%v", x)
+		}
+	}()
+	var rules []GruleJSON
+	err = json.Unmarshal(data, &rules)
+	if err != nil {
+		return
+	}
+	var sb strings.Builder
+	for i := 0; i < len(rules); i++ {
+		sb.WriteString(parseRule(&rules[i]))
+	}
+	rs = sb.String()
+	return
+}
+
+func parseRule(rule *GruleJSON) string {
+	if len(rule.Name) == 0 {
+		panic("rule name cannot be blank")
+	}
+	if rule.When == nil {
+		panic("rule when condition cannot be nil")
+	}
+	if rule.Then == nil {
+		panic("rule thenn condition cannot be nil")
+	}
+	var sb strings.Builder
+	sb.WriteString("rule ")
+	sb.WriteString(rule.Name)
+	sb.WriteString(" ")
+	sb.WriteString(strconv.Quote(rule.Description))
+	sb.WriteString(" salience ")
+	sb.WriteString(strconv.Itoa(rule.Salience))
+	sb.WriteString(" {\n    when\n        ")
+	sb.WriteString(parseWhen(rule.When))
+	sb.WriteString("\n    then\n")
+	thens := parseThen(rule.Then)
+	for i := 0; i < len(thens); i++ {
+		sb.WriteString("        ")
+		sb.WriteString(thens[i])
+		sb.WriteString("\n")
+	}
+	sb.WriteString("}\n")
+	return sb.String()
+}
+
+func parseThen(ts []interface{}) []string {
+	thens := make([]string, len(ts))
+	for i := 0; i < len(ts); i++ {
+		switch x := ts[i].(type) {
+		case string:
+			thens[i] = x
+			if !strings.HasSuffix(thens[i], ";") {
+				thens[i] += ";"
+			}
+		case map[string]interface{}:
+			thens[i] = buildExpression(x, 0) + ";"
+		default:
+			panic("invalid then type, must be a string or an array of action objects")
+		}
+	}
+	return thens
+}
+
+func parseWhen(w interface{}) string {
+	switch x := w.(type) {
+	case string:
+		return x
+	case map[string]interface{}:
+		return buildExpression(x, 0)
+	default:
+		panic("invalid when type, must be a string or an array of condition objects")
+	}
+}
+
+func buildExpression(input map[string]interface{}, depth int) string {
+	exp, _ := buildExpressionEx(input, depth)
+	return exp
+}
+
+func buildExpressionEx(input map[string]interface{}, depth int) (string, bool) {
+	if depth > 1024 {
+		panic("JSON nesting exceeded 1024 levels, aborting")
+	}
+	if len(input) > 1 {
+		panic("expression objects can only contain a single operation type")
+	}
+	for k, v := range input {
+		switch k {
+		case "and":
+			return buildCompoundOperator(v, depth, " && ")
+		case "or":
+			return buildCompoundOperator(v, depth, " || ")
+		case "eq":
+			return joinOperator(v, " == "), false
+		case "not":
+			return joinOperator(v, " != "), false
+		case "gt":
+			return joinOperator(v, " > "), false
+		case "gte":
+			return joinOperator(v, " >= "), false
+		case "lt":
+			return joinOperator(v, " < "), false
+		case "lte":
+			return joinOperator(v, " <= "), false
+		case "bor":
+			return joinOperator(v, " | "), false
+		case "band":
+			return joinOperator(v, " & "), false
+		case "plus":
+			return joinOperator(v, " + "), false
+		case "minus":
+			return joinOperator(v, " - "), false
+		case "div":
+			return joinOperator(v, " / "), false
+		case "mul":
+			return joinOperator(v, " * "), false
+		case "mod":
+			return joinOperator(v, " % "), false
+		case "set":
+			return joinSet(v, " = "), true
+		case "call":
+			return joinCall(v), true
+		case "obj":
+			if s, ok := v.(string); ok {
+				return s, true
+			}
+			panic("object must be a string")
+		case "const":
+			switch x := v.(type) {
+			case string:
+				return strconv.Quote(x), true
+			case float64:
+				return fmt.Sprint(x), true
+			case bool:
+				if x {
+					return "true", true
+				}
+				return "false", true
+			}
+			panic("constant must be a string or a numeric value")
+		default:
+			panic("unknown operator type: " + k)
+		}
+	}
+	panic("boolean expression cannot be empty")
+}
+
+func buildCompoundOperator(o interface{}, depth int, op string) (string, bool) {
+	if andarr, ok := o.([]interface{}); ok {
+		var ands []string
+		if len(andarr) < 2 {
+			panic("and operator must have at least 2 operands")
+		}
+		for i := 0; i < len(andarr); i++ {
+			if subVal, ok := andarr[i].(map[string]interface{}); ok {
+				ands = append(ands, buildExpression(subVal, depth+1))
+			} else {
+				panic("and operands must be an array of objects")
+			}
+		}
+		if depth > 0 {
+			return "(" + strings.Join(ands, op) + ")", false
+		}
+		return strings.Join(ands, op), false
+	}
+	panic("compound operator must be an array")
+}
+
+func joinCall(v interface{}) string {
+	if arr, ok := v.([]interface{}); ok {
+		if len(arr) == 0 {
+			panic("call operator must have at least one operand")
+		}
+		var f string
+		var ok bool
+		if f, ok = arr[0].(string); !ok {
+			panic("first call operand must be a string")
+		}
+		if len(arr) > 1 {
+			sars := make([]string, len(arr)-1)
+			for i := 1; i < len(arr); i++ {
+				sars[i-1] = parseCallOperand(arr[i])
+			}
+			return f + "(" + strings.Join(sars, ", ") + ")"
+		}
+		return f + "()"
+	}
+	panic("operator has an unexpected type")
+}
+
+func parseCallOperand(o interface{}) string {
+	switch x := o.(type) {
+	case string:
+		if len(x) == 0 {
+			panic("operand cannnot be empty")
+		}
+		return x
+	case float64:
+		return fmt.Sprint(x)
+	case bool:
+		if x {
+			return "true"
+		}
+		return "false"
+	case map[string]interface{}:
+		return buildExpression(x, 0)
+	default:
+		panic("operand has an invalid type")
+	}
+}
+
+func joinOperator(v interface{}, op string) string {
+	if arr, ok := v.([]interface{}); ok {
+		if len(arr) == 0 {
+			panic("operator cannot have 0 operands")
+		}
+		ops := make([]string, len(arr))
+		for i := 0; i < len(arr); i++ {
+			ops[i] = parseOperand(arr[i], false)
+		}
+		return strings.Join(ops, op)
+	}
+	panic("operator has an unexpected type")
+}
+
+func joinSet(v interface{}, op string) string {
+	if arr, ok := v.([]interface{}); ok {
+		if len(arr) != 2 {
+			panic("set operand count must be 2")
+		}
+		return parseOperand(arr[0], true) + op + parseOperand(arr[1], true)
+	}
+	panic("operator has an unexpected type")
+}
+
+func parseOperand(o interface{}, noWrap bool) string {
+	switch x := o.(type) {
+	case string:
+		return x
+	case float64:
+		return fmt.Sprint(x)
+	case bool:
+		if x {
+			return "true"
+		}
+		return "false"
+	case map[string]interface{}:
+		expr, expNoWrap := buildExpressionEx(x, 0)
+		if expNoWrap || noWrap {
+			return expr
+		}
+		return "(" + expr + ")"
+	default:
+		panic("operand has an invalid type")
+	}
+}

--- a/pkg/JsonResource_test.go
+++ b/pkg/JsonResource_test.go
@@ -1,0 +1,142 @@
+package pkg
+
+import (
+	"testing"
+)
+
+const jsonData = `[{
+    "name": "SpeedUp",
+    "desc": "When testcar is speeding up we keep increase the speed.",
+    "salience": 10,
+    "when": "TestCar.SpeedUp == true && TestCar.Speed < TestCar.MaxSpeed",
+    "then": [
+        "TestCar.Speed = TestCar.Speed + TestCar.SpeedIncrement",
+        "DistanceRecord.TotalDistance = DistanceRecord.TotalDistance + TestCar.Speed",
+        "Log(\"Speed increased\")"
+    ]
+}]`
+
+const jsonDataExpanded = `[{
+    "name": "SpeedUp",
+    "desc": "When testcar is speeding up we keep increase the speed.",
+    "salience": 10,
+    "when": {
+       "and": [
+           {"eq": ["TestCar.SpeedUp", true]},
+           {"lt": ["TestCar.Speed", "TestCar.MaxSpeed"]}
+       ]
+    },
+    "then": [
+        {"set": ["TestCar.Speed", {"plus": ["TestCar.Speed", "TestCar.SpeedIncrement"]}]},
+        {"set": ["DistanceRecord.TotalDistance", {"plus": ["DistanceRecord.TotalDistance", "TestCar.Speed"]}]},
+        {"call": ["Log", {"const": "Speed increased"}]}
+    ]
+}]`
+
+const jsonDataVerbose = `[{
+    "name": "SpeedUp",
+    "desc": "When testcar is speeding up we keep increase the speed.",
+    "salience": 10,
+    "when": {
+       "and": [
+           {"eq": [{"obj": "TestCar.SpeedUp"}, {"const": true}]},
+           {"lt": [{"obj": "TestCar.Speed"}, {"obj": "TestCar.MaxSpeed"}]}
+       ]
+    },
+    "then": [
+        {"set": [{"obj": "TestCar.Speed"}, {"plus": [{"obj": "TestCar.Speed"}, {"obj": "TestCar.SpeedIncrement"}]}]},
+        {"set": [{"obj": "DistanceRecord.TotalDistance"}, {"plus": [{"obj": "DistanceRecord.TotalDistance"}, {"obj": "TestCar.Speed"}]}]},
+        {"call": ["Log", {"const": "Speed increased"}]}
+    ]
+}]`
+
+const expectedRule = `rule SpeedUp "When testcar is speeding up we keep increase the speed." salience 10 {
+    when
+        TestCar.SpeedUp == true && TestCar.Speed < TestCar.MaxSpeed
+    then
+        TestCar.Speed = TestCar.Speed + TestCar.SpeedIncrement;
+        DistanceRecord.TotalDistance = DistanceRecord.TotalDistance + TestCar.Speed;
+        Log("Speed increased");
+}
+`
+
+const jsonDataEscaped = `[{
+    "name": "SpeedUp",
+    "desc": "When testcar is speeding up we keep increase the \"speed\".",
+    "salience": 10,
+    "when": {
+       "and": [
+           {"eq": [{"obj": "TestCar.SpeedUp"}, {"const": true}]},
+           {"lt": [{"obj": "TestCar.Speed"}, {"obj": "TestCar.MaxSpeed"}]}
+       ]
+    },
+    "then": [
+        {"set": [{"obj": "TestCar.Speed"}, {"plus": [{"obj": "TestCar.Speed"}, {"obj": "TestCar.SpeedIncrement"}]}]},
+        {"set": [{"obj": "DistanceRecord.TotalDistance"}, {"plus": [{"obj": "DistanceRecord.TotalDistance"}, {"obj": "TestCar.Speed"}]}]},
+        {"call": ["Log", {"const": "\"Speed\" increased\n"}]}
+    ]
+}]`
+
+const expectedEscaped = `rule SpeedUp "When testcar is speeding up we keep increase the \"speed\"." salience 10 {
+    when
+        TestCar.SpeedUp == true && TestCar.Speed < TestCar.MaxSpeed
+    then
+        TestCar.Speed = TestCar.Speed + TestCar.SpeedIncrement;
+        DistanceRecord.TotalDistance = DistanceRecord.TotalDistance + TestCar.Speed;
+        Log("\"Speed\" increased\n");
+}
+`
+
+func TestParseJSONRuleset(t *testing.T) {
+	rs, err := ParseJSONRuleset([]byte(jsonData))
+	if err != nil {
+		t.Fatal("Failed to parse flat ruleset: " + err.Error())
+	}
+	t.Log("Flat rule output:")
+	t.Log(rs)
+	if rs != expectedRule {
+		t.Fatal("Parsed rule does not match expected result")
+	}
+	rs, err = ParseJSONRuleset([]byte(jsonDataExpanded))
+	if err != nil {
+		t.Fatal("Failed to parse expanded ruleset: " + err.Error())
+	}
+	t.Log("Expanded rule output:")
+	t.Log(rs)
+	if rs != expectedRule {
+		t.Fatal("Parsed rule does not match expected result")
+	}
+	rs, err = ParseJSONRuleset([]byte(jsonDataVerbose))
+	if err != nil {
+		t.Fatal("Failed to parse verbose ruleset: " + err.Error())
+	}
+	t.Log("Verbose rule output:")
+	t.Log(rs)
+	if rs != expectedRule {
+		t.Fatal("Parsed rule does not match expected result")
+	}
+}
+
+func TestNewJSONResourceFromResource(t *testing.T) {
+	underlyingResource := NewBytesResource([]byte(jsonDataExpanded))
+	resource := NewJSONResourceFromResource(underlyingResource)
+	loaded, err := resource.Load()
+	if err != nil {
+		t.Fatal("Failed to load JSON ruleset: " + err.Error())
+	}
+	t.Log(string(loaded))
+	if string(loaded) != expectedRule {
+		t.Fatal("Loaded rule does not match expected result")
+	}
+}
+
+func TestJSONStringEscaping(t *testing.T) {
+	rs, err := ParseJSONRuleset([]byte(jsonDataEscaped))
+	if err != nil {
+		t.Fatal("Failed to parse flat ruleset: " + err.Error())
+	}
+	t.Log(rs)
+	if rs != expectedEscaped {
+		t.Fatal("Rule output doe not match expected value")
+	}
+}


### PR DESCRIPTION
Hi,

This PR would add initial support for storing rules in a JSON format and translating them at runtime into GRL syntax to be used by the engine.

The format fo the JSON is designed with the greatest flexibility in mind, allowing rule writers to be as explicit as they need to be.

This initial implementation simply translates rules to GRL syntax, if the input JSON is invalid it will result in the generation of invalid GRL rules since the translator does not do full syntax validation. It will catch many potential mistakes but not all of them.

I wasn't sure of the best place to put the translator, but I settled on putting it alongside the Resource loaders as it seemed to fit well there, making it very easy to parse JSON rules inline and fitting well with existing code.

Will be interested to hear your thoughts on this approach.

This PR will also address issue #71 