### PR TITLE
Feat/context support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,3 +83,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `escape` character in string literal
 - `RuleBuilder` is now to build rules in GRLs into `KnowledgeLibrary`
 - Now you should obtain a `KnowledgeBase` instance from `KnowledgeLibrary`. This enable concurrency model in Grule. See `examples/Concurrency_test.go` to know how it works. 
+
+### [1.5.0] - 2020-08-02
+
+#### Added
+
+- Support to build rule from JSON.
+- Engine support for `context.Context` using `ExecuteWithContext` function. 

--- a/builder/RuleBuilder.go
+++ b/builder/RuleBuilder.go
@@ -9,7 +9,6 @@ import (
 	parser2 "github.com/hyperjumptech/grule-rule-engine/antlr/parser/grulev2.g4"
 	"github.com/hyperjumptech/grule-rule-engine/ast"
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
-	"github.com/juju/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -61,7 +60,7 @@ func (builder *RuleBuilder) BuildRuleFromResources(name, version string, resourc
 	for _, v := range resource {
 		err := builder.BuildRuleFromResource(name, version, v)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 	return nil
@@ -75,7 +74,7 @@ func (builder *RuleBuilder) BuildRuleFromResource(name, version string, resource
 	// Load the resource
 	data, err := resource.Load()
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	sdata := string(data)
 
@@ -105,7 +104,7 @@ func (builder *RuleBuilder) BuildRuleFromResource(name, version string, resource
 
 	if parseError != nil {
 		log.Errorf("Loading rule resource : %s failed. Got %v. Time take %d ms", resource.String(), parseError, dur.Nanoseconds()/1e6)
-		return errors.Errorf("error were found before builder bailing out. Got %v", parseError)
+		return fmt.Errorf("error were found before builder bailing out. Got %v", parseError)
 	}
 
 	log.Debugf("Loading rule resource : %s success. Time taken %d ms", resource.String(), dur.Nanoseconds()/1e6)

--- a/docs/RETE_en.md
+++ b/docs/RETE_en.md
@@ -107,7 +107,7 @@ rule ... {
 Grule will try to remember all of the `Expression` defined within rule's `when` scope of all rules
 in the KnowledgeBase.
 
-First, It will try its best to make sure none of the `v` AST (Abstract Syntax Tree) node get duplicated.
+First, It will try its best to make sure none of the AST (Abstract Syntax Tree) node get duplicated.
 
 Second, each of this AST node can only be evaluated once, until it's relevant `variable` get changed. For example :
 

--- a/docs/Tutorial_en.md
+++ b/docs/Tutorial_en.md
@@ -185,6 +185,10 @@ for _, res := range resources {
 }
 ```
 
+#### From JSON
+
+You can now build rules from JSON!,  [Read how it works](GRL_JSON_en.md) 
+
 Now, in the `KnowledgeLibrary` we have a `KnowledgeBase` named `TutorialRules` with version `0.0.1`. To execute this particular rule, you have to obtain an instance of it from the `KnowledgeLibrary`. This will be explained on the next section.
 
 ## Executing Grule Rule Engine

--- a/engine/GruleEngine.go
+++ b/engine/GruleEngine.go
@@ -109,7 +109,7 @@ func (g *GruleEngine) ExecuteWithContext(ctx context.Context, dataCtx ast.IDataC
 		if cycle > g.MaxCycle {
 
 			// create the error
-			err := fmt.Errorf("GruleEngine successfully selected rule candidate for execution after %d cycles, this could possibly caused by rule entry(s) that keep added into execution pool but when executed it does not change any data in context. Please evaluate your rule entries \"When\" and \"Then\" scope. You can adjust the maximum cycle using GruleEngine.MaxCycle variable.", g.MaxCycle)
+			err := fmt.Errorf("the GruleEngine successfully selected rule candidate for execution after %d cycles, this could possibly caused by rule entry(s) that keep added into execution pool but when executed it does not change any data in context. Please evaluate your rule entries \"When\" and \"Then\" scope. You can adjust the maximum cycle using GruleEngine.MaxCycle variable", g.MaxCycle)
 
 			// emit engine error event
 			RuleEnginePublisher.Publish(&events.RuleEngineEvent{

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,6 @@ require (
 	github.com/golang/mock v1.4.3
 	github.com/google/uuid v1.1.1
 	github.com/imkira/go-observer v1.0.3
-	github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9
-	github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8 // indirect
-	github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b // indirect
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,14 +31,6 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/juju/errors v0.0.0-20190806202954-0232dcc7464d h1:hJXjZMxj0SWlMoQkzeZDLi2cmeiWKa7y1B8Rg+qaoEc=
-github.com/juju/errors v0.0.0-20190806202954-0232dcc7464d/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
-github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9 h1:hJix6idebFclqlfZCHE7EUX7uqLCyb70nHNHH1XKGBg=
-github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
-github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8 h1:UUHMLvzt/31azWTN/ifGWef4WUqvXk0iRqdhdy/2uzI=
-github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
-github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b h1:Rrp0ByJXEjhREMPGTt3aWYjoIsUGCbt21ekbeJcTWv0=
-github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v2wtGp9Gmz1Ze3eVRAWJMLokvN3QjdzCHLY=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/pkg/gitresource_1.10.go
+++ b/pkg/gitresource_1.10.go
@@ -2,9 +2,11 @@
 
 package pkg
 
-import "github.com/juju/errors"
+import (
+	"fmt"
+)
 
 // Load will load the file from your git repository
 func (bundle *GITResourceBundle) Load() ([]Resource, error) {
-	return nil, errors.New("GIT resources are not supported with Go 1.10 or below")
+	return nil, fmt.Errorf("GIT resources are not supported with Go 1.10 or below")
 }

--- a/pkg/reflectools.go
+++ b/pkg/reflectools.go
@@ -6,14 +6,13 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/juju/errors"
 	"github.com/sirupsen/logrus"
 )
 
 // GetFunctionList get list of functions in a struct instance
 func GetFunctionList(obj interface{}) ([]string, error) {
 	if !IsStruct(obj) {
-		return nil, errors.Errorf("param is not a struct")
+		return nil, fmt.Errorf("param is not a struct")
 	}
 	ret := make([]string, 0)
 
@@ -27,7 +26,7 @@ func GetFunctionList(obj interface{}) ([]string, error) {
 // GetFunctionParameterTypes get list of parameter types of specific function in a struct instance
 func GetFunctionParameterTypes(obj interface{}, methodName string) ([]reflect.Type, bool, error) {
 	if !IsStruct(obj) {
-		return nil, false, errors.Errorf("param is not a struct")
+		return nil, false, fmt.Errorf("param is not a struct")
 	}
 	ret := make([]reflect.Type, 0)
 	objType := reflect.TypeOf(obj)
@@ -48,13 +47,13 @@ func GetFunctionParameterTypes(obj interface{}, methodName string) ([]reflect.Ty
 		}
 		return ret, meth.Type.IsVariadic(), nil
 	}
-	return nil, false, errors.Errorf("function %s not found", methodName)
+	return nil, false, fmt.Errorf("function %s not found", methodName)
 }
 
 // GetFunctionReturnTypes get list of return types of specific function in a struct instance
 func GetFunctionReturnTypes(obj interface{}, methodName string) ([]reflect.Type, error) {
 	if !IsStruct(obj) {
-		return nil, errors.Errorf("param is not a struct")
+		return nil, fmt.Errorf("param is not a struct")
 	}
 	ret := make([]reflect.Type, 0)
 	objType := reflect.TypeOf(obj)
@@ -66,7 +65,7 @@ func GetFunctionReturnTypes(obj interface{}, methodName string) ([]reflect.Type,
 			ret = append(ret, x.Out(i))
 		}
 	} else {
-		return nil, errors.Errorf("function %s not found", methodName)
+		return nil, fmt.Errorf("function %s not found", methodName)
 	}
 	return ret, nil
 }
@@ -74,7 +73,7 @@ func GetFunctionReturnTypes(obj interface{}, methodName string) ([]reflect.Type,
 // InvokeFunction invokes a specific function in a struct instance, using parameters array
 func InvokeFunction(obj interface{}, methodName string, param []interface{}) ([]interface{}, error) {
 	if !IsStruct(obj) {
-		return nil, errors.Errorf("param is not a struct")
+		return nil, fmt.Errorf("param is not a struct")
 	}
 	var objVal reflect.Value
 	if reflect.TypeOf(obj).Name() == "Value" {
@@ -85,7 +84,7 @@ func InvokeFunction(obj interface{}, methodName string, param []interface{}) ([]
 	funcVal := objVal.MethodByName(methodName)
 
 	if !funcVal.IsValid() {
-		return nil, errors.New(fmt.Sprintf("invalid function %s", methodName))
+		return nil, fmt.Errorf("invalid function %s", methodName)
 	}
 
 	argVals := make([]reflect.Value, len(param))
@@ -182,7 +181,7 @@ func ValueToInterface(v reflect.Value) interface{} {
 // GetAttributeList will populate list of struct's public member variable.
 func GetAttributeList(obj interface{}) ([]string, error) {
 	if !IsStruct(obj) {
-		return nil, errors.Errorf("param is not a struct")
+		return nil, fmt.Errorf("param is not a struct")
 	}
 	strRet := make([]string, 0)
 	v := reflect.ValueOf(obj)
@@ -196,10 +195,10 @@ func GetAttributeList(obj interface{}) ([]string, error) {
 // GetAttributeValue will retrieve a members variable value.
 func GetAttributeValue(obj interface{}, fieldName string) (reflect.Value, error) {
 	if !IsStruct(obj) {
-		return reflect.ValueOf(nil), errors.Errorf("param is not a struct")
+		return reflect.ValueOf(nil), fmt.Errorf("param is not a struct")
 	}
 	if !IsValidField(obj, fieldName) {
-		return reflect.ValueOf(nil), errors.Errorf("attribute named %s not exist in struct", fieldName)
+		return reflect.ValueOf(nil), fmt.Errorf("attribute named %s not exist in struct", fieldName)
 	}
 	structval := reflect.ValueOf(obj)
 	var attrVal reflect.Value
@@ -223,10 +222,10 @@ func GetAttributeInterface(obj interface{}, fieldName string) (interface{}, erro
 // GetAttributeType will return the type of a specific member variable
 func GetAttributeType(obj interface{}, fieldName string) (reflect.Type, error) {
 	if !IsStruct(obj) {
-		return nil, errors.Errorf("param is not a struct")
+		return nil, fmt.Errorf("param is not a struct")
 	}
 	if !IsValidField(obj, fieldName) {
-		return nil, errors.Errorf("attribute named %s not exist in struct", fieldName)
+		return nil, fmt.Errorf("attribute named %s not exist in struct", fieldName)
 	}
 	structval := reflect.ValueOf(obj)
 	var attrVal reflect.Value
@@ -241,10 +240,10 @@ func GetAttributeType(obj interface{}, fieldName string) (reflect.Type, error) {
 // SetAttributeValue will try to set a member variable value with a new one.
 func SetAttributeValue(obj interface{}, fieldName string, value reflect.Value) error {
 	if !IsStruct(obj) {
-		return errors.Errorf("param is not a struct")
+		return fmt.Errorf("param is not a struct")
 	}
 	if !IsValidField(obj, fieldName) {
-		return errors.Errorf("attribute named %s not exist in struct", fieldName)
+		return fmt.Errorf("attribute named %s not exist in struct", fieldName)
 	}
 	var fieldVal reflect.Value
 	objType := reflect.TypeOf(obj)
@@ -256,7 +255,7 @@ func SetAttributeValue(obj interface{}, fieldName string, value reflect.Value) e
 			fieldVal = objVal.Elem().FieldByName(fieldName)
 		} else {
 			// If its not point to struct ... return error
-			return errors.Errorf("object is pointing a non struct. %s", objType.Elem().Kind().String())
+			return fmt.Errorf("object is pointing a non struct. %s", objType.Elem().Kind().String())
 		}
 	} else {
 		// If Obj param is not a pointer.
@@ -265,13 +264,13 @@ func SetAttributeValue(obj interface{}, fieldName string, value reflect.Value) e
 			fieldVal = objVal.FieldByName(fieldName)
 		} else {
 			// If its not a struct ... return error
-			return errors.Errorf("object is not a struct. %s", objType.Kind().String())
+			return fmt.Errorf("object is not a struct. %s", objType.Kind().String())
 		}
 	}
 
 	// Check source data type compatibility with the field type
 	if GetBaseKind(fieldVal) != GetBaseKind(value) { // pointer check
-		return errors.Errorf("can not assign type %s to %s", value.Type().String(), fieldVal.Type().String())
+		return fmt.Errorf("can not assign type %s to %s", value.Type().String(), fieldVal.Type().String())
 	}
 	if fieldVal.CanSet() {
 		switch fieldVal.Type().Kind() {
@@ -295,33 +294,33 @@ func SetAttributeValue(obj interface{}, fieldName string, value reflect.Value) e
 			break
 		case reflect.Slice:
 			// todo Add setter for slice type field
-			return errors.Errorf("unsupported operation to set slice")
+			return fmt.Errorf("unsupported operation to set slice")
 		case reflect.Array:
 			// todo Add setter for array type field
-			return errors.Errorf("unsupported operation to set array")
+			return fmt.Errorf("unsupported operation to set array")
 		case reflect.Map:
 			// todo Add setter for map type field
-			return errors.Errorf("unsupported operation to set map")
+			return fmt.Errorf("unsupported operation to set map")
 		case reflect.Struct:
 			if value.IsValid() {
 				if ValueToInterface(value) == nil {
-					return errors.Errorf("Time set failed 1")
+					return fmt.Errorf("Time set failed 1")
 				}
 				fieldVal.Set(value)
 				//t := ValueToInterface(fieldVal).(time.Time)
 				if ValueToInterface(fieldVal) == nil {
-					return errors.Errorf("Time set failed 2")
+					return fmt.Errorf("Time set failed 2")
 				}
 			} else {
-				return errors.Errorf("Setting with nil is not allowed")
+				return fmt.Errorf("Setting with nil is not allowed")
 			}
 			//// todo Add setter for slice type field
-			//return errors.Errorf("unsupported operation to set struct")
+			//return fmt.Errorf("unsupported operation to set struct")
 		default:
 			return nil
 		}
 	} else {
-		return errors.Errorf("can not set field")
+		return fmt.Errorf("can not set field")
 	}
 	return nil
 }
@@ -329,10 +328,10 @@ func SetAttributeValue(obj interface{}, fieldName string, value reflect.Value) e
 // SetAttributeInterface will try to set a member variable value with a value from an interface
 func SetAttributeInterface(obj interface{}, fieldName string, value interface{}) error {
 	if !IsStruct(obj) {
-		return errors.Errorf("param is not a struct")
+		return fmt.Errorf("param is not a struct")
 	}
 	if !IsValidField(obj, fieldName) {
-		return errors.Errorf("attribute named %s not exist in struct", fieldName)
+		return fmt.Errorf("attribute named %s not exist in struct", fieldName)
 	}
 
 	return SetAttributeValue(obj, fieldName, reflect.ValueOf(value))
@@ -341,10 +340,10 @@ func SetAttributeInterface(obj interface{}, fieldName string, value interface{})
 // IsAttributeArray validate if a member variable is an array or a slice.
 func IsAttributeArray(obj interface{}, fieldName string) (bool, error) {
 	if !IsStruct(obj) {
-		return false, errors.Errorf("param is not a struct")
+		return false, fmt.Errorf("param is not a struct")
 	}
 	if !IsValidField(obj, fieldName) {
-		return false, errors.Errorf("attribute named %s not exist in struct", fieldName)
+		return false, fmt.Errorf("attribute named %s not exist in struct", fieldName)
 	}
 	objVal := reflect.ValueOf(obj)
 	fieldVal := objVal.Elem().FieldByName(fieldName)
@@ -354,10 +353,10 @@ func IsAttributeArray(obj interface{}, fieldName string) (bool, error) {
 // IsAttributeMap validate if a member variable is a map.
 func IsAttributeMap(obj interface{}, fieldName string) (bool, error) {
 	if !IsStruct(obj) {
-		return false, errors.Errorf("param is not a struct")
+		return false, fmt.Errorf("param is not a struct")
 	}
 	if !IsValidField(obj, fieldName) {
-		return false, errors.Errorf("attribute named %s not exist in struct", fieldName)
+		return false, fmt.Errorf("attribute named %s not exist in struct", fieldName)
 	}
 	objVal := reflect.ValueOf(obj)
 	fieldVal := objVal.Elem().FieldByName(fieldName)
@@ -367,10 +366,10 @@ func IsAttributeMap(obj interface{}, fieldName string) (bool, error) {
 // IsAttributeNilOrZero validate if a member variable is nil or zero.
 func IsAttributeNilOrZero(obj interface{}, fieldName string) (bool, error) {
 	if !IsStruct(obj) {
-		return false, errors.Errorf("param is not a struct")
+		return false, fmt.Errorf("param is not a struct")
 	}
 	if !IsValidField(obj, fieldName) {
-		return false, errors.Errorf("attribute named %s not exist in struct", fieldName)
+		return false, fmt.Errorf("attribute named %s not exist in struct", fieldName)
 	}
 	objVal := reflect.ValueOf(obj)
 	fieldVal := objVal.Elem().FieldByName(fieldName)

--- a/pkg/resource.go
+++ b/pkg/resource.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/bmatcuk/doublestar"
-	"github.com/juju/errors"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/src-d/go-billy.v4"
 )
@@ -153,7 +152,7 @@ func (res *FileResource) Load() ([]byte, error) {
 	}
 	data, err := ioutil.ReadFile(res.Path)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	res.Bytes = data
 	return res.Bytes, nil
@@ -214,12 +213,12 @@ func (res *URLResource) Load() ([]byte, error) {
 	}
 	resp, err := http.Get(res.URL)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	res.Bytes = data
 	return res.Bytes, nil


### PR DESCRIPTION
Enabling context support for the engine. This will enable the engine to be canceled of its operation using context cancelation mechanism.

In addition to `Execute(dataCtx ast.IDataContext, knowledge *ast.KnowledgeBase) error` we now have `ExecuteWithContext(ctx context.Context, dataCtx ast.IDataContext, knowledge *ast.KnowledgeBase) error`

Where you can specify the time out for engine to run. For example :

```go
engine := NewGruleEngine()
ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
defer cancel()
err = engine.ExecuteWithContext(ctx, dctx, kb)
```

This could make `maxCycle` rather obsolete.

Another additional change, I removed dependency to `juju` logging, as we already used logrus. There is no reason to use two logging framework in a project, i think.