### PR TITLE
Export parseRule utility function

### DIFF
--- a/pkg/JsonResource.go
+++ b/pkg/JsonResource.go
@@ -101,13 +101,14 @@ func ParseJSONRuleset(data []byte) (rs string, err error) {
 	}
 	var sb strings.Builder
 	for i := 0; i < len(rules); i++ {
-		sb.WriteString(parseRule(&rules[i]))
+		sb.WriteString(ParseRule(&rules[i]))
 	}
 	rs = sb.String()
 	return
 }
 
-func parseRule(rule *GruleJSON) string {
+// ParseRule Accepts a struct of GruleJSON rule and returns the parsed string of GRule.
+func ParseRule(rule *GruleJSON) string {
 	if len(rule.Name) == 0 {
 		panic("rule name cannot be blank")
 	}


### PR DESCRIPTION
`ParseJSONRuleset` is useful when parsing between json and grule formats, however it only works for arrays of rules. I'm just exporting the singular parsing of GruleJSON to grule(string) to be usable outside of `pkg`