### PR TITLE
Catch panics produced by the public ParseRule function

### DIFF
--- a/pkg/JsonResource.go
+++ b/pkg/JsonResource.go
@@ -101,14 +101,24 @@ func ParseJSONRuleset(data []byte) (rs string, err error) {
 	}
 	var sb strings.Builder
 	for i := 0; i < len(rules); i++ {
-		sb.WriteString(ParseRule(&rules[i]))
+		sb.WriteString(parseRule(&rules[i]))
 	}
 	rs = sb.String()
 	return
 }
 
 // ParseRule Accepts a struct of GruleJSON rule and returns the parsed string of GRule.
-func ParseRule(rule *GruleJSON) string {
+func ParseRule(rule *GruleJSON) (r string, err error) {
+	defer func() {
+		if x := recover(); x != nil {
+			err = fmt.Errorf("%v", x)
+		}
+	}()
+	r = parseRule(rule)
+	return
+}
+
+func parseRule(rule *GruleJSON) string {
 	if len(rule.Name) == 0 {
 		panic("rule name cannot be blank")
 	}


### PR DESCRIPTION
Hello,

This PR makes a small change so that the recently exposed ParseRule function for parsing of a JSON rule will return an error if parsing fails rather than causing a panic.

Originally the function was only used internally and it was called in a code path which is protected by a deferred recover() call. This was done in order to greatly simplify the error handling in the JSON parser. Now that the function is exposed publicly, I think it would be better if it returned an error rather than panicking and risking crashing an entire application due to a JSON parse error.

To achieve this, I un-exported the existing function so it can still be used in the same way internally and created a wrapper exported ParseRule function which calls parseRule with the protection of a deferred recover() call.

Thanks,
Niall