### PR TITLE
Check all interface conversion in the parser and abort if a failure o…

### DIFF
--- a/examples/benchmark/DummyRuleMaker.go
+++ b/examples/benchmark/DummyRuleMaker.go
@@ -101,7 +101,7 @@ func MakeRule(seq int) string {
 
 // GenRandomRule simply generate count number of simple parse-able rule into a file
 func GenRandomRule(fileName string, count int) error {
-	f, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY, 666)
+	f, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
…ccurs

* When Presented with syntactically incorrect rules, the parser may generate a
panic when attempting to type case an AST element. If this occurs, the panic
may propagate to third party code resulting in an application crash.
* All type casts are now done safely and are checked for success. If a cast
fails, parsing is aborted by setting StopParse to true and returning immediately.
This allows ANTLR to return a syntax error to the caller.
* A new test has been added to validate that the parser will not crash when
presented with invalid rule input. The test cases have been designed
specifically to mis-use GRL keywords as well as misplace otherwise correct
keywords within a rule.