### PR TITLE
Made an editing pass, and included clarification sentence

### DIFF
--- a/docs/RuleEngine_en.md
+++ b/docs/RuleEngine_en.md
@@ -4,22 +4,21 @@
 
 ---
 
-A Rule Engine, as Martin Fowler explained, is an alternative to the computational model.
-Where you evaluate multiple conditions, by which you then select an appropriate action if certain
+A Rule Engine, as Martin Fowler explained, is an alternative to the computational model, instead
+evaluating multiple conditions, by which an appropriate action is selected if certain
 conditions are met. In the simplest explanation, each *Rule* depicts an *if-then* statement.
 
-You feed a collection of rules into a **KnowledgeBase**, then the *engine* uses each 
+You feed a collection of rules into a **KnowledgeBase**, and then the *engine* uses each 
 rule inside the KnowledgeBase to evaluate some **Facts**. If a rule's requirements are met,
-the **action** specified by that selected rule will be executed.
+the **action** specified by the selected rule will be executed.
 
 ## Fact
 
-A `fact` is a fact, as silly it may sound but that's what it is. Fact, in rule engine context,
-is basically a piece of information that can be evaluated. Fact can be from any source, eg.
-Database, triggered process, point of sales, reports, etc.
+A `fact` is a fact, as silly it may sound, but that's what it is. A Fact, in rule engine context,
+is basically a piece of information that can be evaluated. Facts can be from any source, eg. a
+database, triggered process, point of sale system, report, etc.
 
-If you still can't picture it, it would be much easier to just look
-at an example of a fact. Suppose we have this fact:
+It might be much easier to just look at an example of a Fact. Suppose we have this Fact:
 
 ```Text
 Purchase Transaction
@@ -33,26 +32,26 @@ Purchase Transaction
     Final Price   : ?
 ```
 
-As you can see, a **Fact** is basically any information or data about something.
+A **Fact** is basically any piece of information or collected data. 
 
-From this sample Purchasing fact, we know lots of information: the item being purchased, the quantity,
-purchase date, etc. However, we don't know how much tax should be assigned to that purchase,
+From this sample Purchasing Fact, we know lots of information: the item being purchased, the quantity,
+the purchase date, etc. However, we don't know how much tax should be assigned to that purchase,
 how much discount we can give, and the final price the buyer should pay.
 
 ## Rule
 
-A rule is a specification about how to evaluate a **Fact**. If the rule's
-conditions are met by the Fact, then the rule's action will be selected to be
-executed.  Sometimes, multiple rules are selected because their specifications
-all meet the Fact, which results in a conflict. The collection of all rules in
+A Rule is a specification about how to evaluate a **Fact**. If a Rule's
+conditions are met by a Fact, then the Rule's action will be selected to be
+executed. Sometimes, multiple Rules are selected because their specifications
+all apply to a Fact, which results in a conflict. The collection of all Rules in
 a conflict are called **Conflict Set**. To resolve this conflict set, we
-specify a *strategy* that we will cover later.  
+specify a *strategy* (covered later, below).  
 
-Back to our example, as in a simple *purchasing* system, some business rules should be established in order to
-calculate the final price, like calculating the tax first and then the discount. When both tax and discount
-are known, we can show the price.
+Back to our example of a simple purchasing system: some business Rules should be established in order to
+calculate the final price, probably calculating the tax first, and then the discount. If both the tax and 
+discount are known, we can show the price.
 
-Let's specify some rules.
+Let's specify some Rules (in psuedocode).
 
 ```text
 Rule 1
@@ -110,36 +109,36 @@ Rule 7
      with given Tax and Discount
 ```
 
-If you examine the above rules, you should easily understand the meaning
-of **rule**. These collection of rules will form a **Knowledge**. A knowledge of
-**"How to calculate Item's final price"**.
+If you examine the above Rules, you should easily understand the of **Rule** concept for Rule Engines. 
+These collection of rules will form a set of **Knowledge**. In this case, they form a Knowledge set of
+**"how to calculate Item's final price"**.
 
 ## Cycle
 
-A rule evaluation cycle will start with evaluating each of the rule's requirements (the **IFs**)
-to select which rule to potentially execute. Every time the engine finds a satisfied
-requirement, instead of executing the satisfied rule's action (the **THENs**), it adds
-that rule into a list of rule candidate (Conflict Set).
+A Rule evaluation cycle starts by evaluating each Rule's requirements (the **IFs**)
+to select which Rules to potentially execute. Every time the engine finds a satisfied
+requirement, instead of executing the satisfied Rule's action (the **THENs**), it adds
+that Rule into a list of Rule candidates (called the Conflict Set).
 
-When all rules' requirements have been evaluated,
-will the engine execute the selected rule's action?  That depends on the contents of the conflict set:
+When all Rules' requirements have been evaluated, does the engine execute the selected Rules' actions?  
+That depends on the contents of the conflict set:
 
-* If there's no Rule inside, that means the Engine execution is finished.
-* If theres only 1 rule inside the conflict set then that action is executed immediately.
-* If there are multiple rules, the engine need to apply some strategy to select one rule and execute its action.
+* If there's no Rule with a matching **IF** condition, the Engine execution can immediately finish.
+* If there's only one Rule inside the Conflict Set, then that Rule's action is executed before finishing.
+* If there are multiple Rules in the Conflict Set, the engine must apply a strategy to prioritize one Rule and execute its action.
 
-If an action gets executed, the cycle repeats again as long as there's an action that needs execution.
-When no more actions get executed, this means that there are no more rule that are statisfied
-by the fact, the cycle stops and the rule engine is finished.
+If an action gets executed, the cycle repeats again, as long as there's an action that needs execution.
+When no more actions get executed, this indicates that there are no more Rules that are statisfied
+by the fact (no more matching **IF** statements), and the cycle stops, letting the Rule engine finish evalutation.
 
-The *Pseudo Code* for this depicted bellow
+The pseudocode for this conflict resolution strategy is depicted below:
 
 ```text
-Start Engine With a FACT using a KNOWLEDGE
+Start Engine With a FACT Using a KNOWLEDGE
 BEGIN
     For Every RULE in KNOWLEDGE
-        Check if RULE's Requirement is satisfied by FACT
-            If RULE's Requirement is satisfied
+        Check if RULE's Requirement is Satisfied by FACT
+            If RULE's Requirement is Satisfied
                 Add RULE into CONFLICT SET
             End If
         End Check
@@ -147,32 +146,34 @@ BEGIN
     If CONFLICT SET is EMPTY
         Finished
         END
-    If CONFLICT SET has 1 RULE
+    If CONFLICT SET Has 1 RULE
         Execute the RULE's Action
         Clear CONFLICT SET
-        Repeat cycle from BEGIN
+        Repeat Cycle from BEGIN
     If CONFLICT SET has Many RULEs
-        Apply Conflict resolution strategy to choose 1 RULE.
-        Execute the chosen RULE's Action
+        Apply Conflict Resolution Strategy to Choose 1 RULE.
+        Execute the Chosen RULE's Action
         Clear CONFLICT SET
-        Repeat cycle from BEGIN
+        Repeat Cycle from BEGIN
 END
 ```
 
-Grule will keep track of how many cycles it has been repeating. If the rule evaluation and execution have
-been repeated too many times, above a specific amount of cycles, the engine will terminate
-and an error will be emitted.
+Grule will keep track of how many cycles it performs in a single evaluation of a ruleset. 
+If the Rule evaluation and execution have been repeated too many times, over and above an 
+amount specified upon instantiating a Grule engine instance, the engine will terminate and 
+an error will be returned.
 
 ## Conflict Set Resolution Strategy
 
-As explained above, the rule engine will evaluate all rules' requirements and add
-them into a list of conflicting rules called the **Conflict Set**. If only 1 rule is
-inside the list, it means that are no rule(s) conflicting with that 1 rule. The engine
-will immediately execute the rule's action.
+As explained above, the Rule engine will evaluate all Rules' requirements and add
+them into a list of conflicting Rules called the **Conflict Set**. If only one Rule is
+inside the list, it means that are no Rule(s) conflicting with that noe Rule. The engine
+will immediately execute the Rule's action.
 
-If there are multiple rules, there maybe conflicts. There are many conflict resolution strategies that
-can be implemented. The easiest way to do it is by specifying the rule's **salience** (also known as
-**priority** or **importance**). We add some indicator into the rule definition such as:
+If there are multiple Rules inside the set, there maybe conflicts. There are many conflict resolution 
+strategies that can be implemented for this type of Ruel conflict resolution. The easiest way to resolve
+is through specification of a Rule's **salience** (also known as **priority** or **importance**). 
+We can add an indicator of Rule **salience** or importance into a Rule definition like in the pseudocode below:
 
 ```text
 Rule 1 - Priority 1
@@ -188,16 +189,16 @@ Rule 2 - Priority 10
    - the Item's Name is "Computer Monitor"
    THEN
    - Item's Tax is 7%
-
-...
 ```
 
-By default, all rules are assigned a salience of `0`.
+By default, all Rules are assigned a salience of `0`.
 
-This way, it's easy for the engine to pick which rule to execute when there are multiple
-conflicting rules. If there are multiple rules with similarly top priorities, the engine
-will pick the first one found.
+Because all nonspecified Rules are salience 0, it's easy for the engine to pick which Rule 
+to execute when there are multiple Rules in the Conflict Set. If there are multiple Rules 
+with matching priorities, the engine will choose the first one found. Because Go's map types 
+are not guaranteed to preserve input order, it is not safe to assume that rule evaluation order 
+will match the order in which Rules are added to a Grule knowledge instance. 
 
-Salience can be a value below zero (negative) to ensure the rule has even lower
-priority. This will to ensure that the rule's action will be executed last,
-after all other rules are met.
+Salience for Grule Rules can be a value below zero (reaching into the negative) to ensure a 
+Rule has even lower priority than the default. This will ensure that a Rule's action will be 
+executed last, after all other Rules are evaluated.


### PR DESCRIPTION
Attempted to clarify grammar and style throughout. 

Added one sentence:
```Because Go's map types are not guaranteed to preserve input order, it is not safe to assume that rule evaluation order will match the order in which Rules are added to a Grule knowledge instance. ```