### PR TITLE
Fix struct name typo

### DIFF
--- a/builder/RuleBuilder.go
+++ b/builder/RuleBuilder.go
@@ -64,7 +64,7 @@ func (builder *RuleBuilder) MustBuildRuleFromResource(name, version string, reso
 }
 
 // BuildRulesFromBundle will load rules from a bundle into knowledge base.
-func (builder *RuleBuilder) BuildRulesFromBundle(name, version string, bundle pkg.ResouceBundle) error {
+func (builder *RuleBuilder) BuildRulesFromBundle(name, version string, bundle pkg.ResourceBundle) error {
 	bundles, err := bundle.Load()
 	if err != nil {
 		return err
@@ -73,7 +73,7 @@ func (builder *RuleBuilder) BuildRulesFromBundle(name, version string, bundle pk
 }
 
 // MustBuildRulesFromBundle is the same with BuildRulesFromBundle but it will panic if any error arises during loading resource and inserting it to knowledgebase
-func (builder *RuleBuilder) MustBuildRulesFromBundle(name, version string, bundle pkg.ResouceBundle) {
+func (builder *RuleBuilder) MustBuildRulesFromBundle(name, version string, bundle pkg.ResourceBundle) {
 	builder.MustBuildRuleFromResources(name, version, bundle.MustLoad())
 }
 

--- a/pkg/JsonResource.go
+++ b/pkg/JsonResource.go
@@ -39,7 +39,7 @@ type JSONResource struct {
 
 // JSONResourceBundle will parse a set of rules in JSON format from an underlying bundle resource provider.
 type JSONResourceBundle struct {
-	subRes ResouceBundle
+	subRes ResourceBundle
 }
 
 // NewJSONResourceFromResource innstantiates a new JSON resource parser from an underlying Resource.
@@ -81,7 +81,7 @@ func (jr *JSONResource) String() string {
 }
 
 // NewJSONResourceBundleFromBundle innstantiates a new bundled JSON resource parser from an underlying ResourceBundle.
-func NewJSONResourceBundleFromBundle(bundle ResouceBundle) ResouceBundle {
+func NewJSONResourceBundleFromBundle(bundle ResourceBundle) ResourceBundle {
 	if _, ok := bundle.(*JSONResourceBundle); ok {
 		panic("cannot create JSON resource bundle from JSON resource bundle")
 	}

--- a/pkg/resource.go
+++ b/pkg/resource.go
@@ -27,8 +27,8 @@ import (
 	"gopkg.in/src-d/go-billy.v4"
 )
 
-// ResouceBundle is a helper struct to help load multiple resource at once.
-type ResouceBundle interface {
+// ResourceBundle is a helper struct to help load multiple resource at once.
+type ResourceBundle interface {
 	Load() ([]Resource, error)
 	MustLoad() []Resource
 }


### PR DESCRIPTION
## Description

The `ResourceBundle` struct had a typo in it. Fixed it!