### PR TITLE
Feature - git authentication

### DIFF
--- a/docs/en/Tutorial_en.md
+++ b/docs/en/Tutorial_en.md
@@ -289,6 +289,21 @@ for _, res := range resources {
 }
 ```
 
+#### GIT with authentication
+For private GIT repositories, you may supply username and password or an auth token.
+In the case of an auth token, supply the token as the `password` argument, and set the `username` argument to be any string with length >= 1
+
+```go
+bundle := pkg.NewGITResourceBundleWithAuth("https://github.com/hyperjumptech/grule-rule-engine.git", "username", "password|token", "/**/*.grl")
+resources := bundle.MustLoad()
+for _, res := range resources {
+    err := ruleBuilder.BuildRuleFromResource("TutorialRules", "0.0.1", res)
+    if err != nil {
+        panic(err)
+    }
+}
+```
+
 ### From JSON
 
 You can now build rules from JSON! [Read how it works](GRL_JSON_en.md) 

--- a/pkg/resource.go
+++ b/pkg/resource.go
@@ -266,6 +266,13 @@ func NewGITResourceBundle(url string, pathPattern ...string) *GITResourceBundle 
 	}
 }
 
+func NewGITResourceBundleWithAuth(url string, user string, password string, pathPattern ...string) *GITResourceBundle {
+	resource := NewGITResourceBundle(url, pathPattern...)
+	resource.User = user
+	resource.Password = password
+	return resource
+}
+
 // GITResourceBundle is a helper struct to load multiple files from GIT all at once by specifying
 // the necessary information needed to communicate to the GIT server.
 // It will look into sub-directories, in the git, for the file with pattern matching.


### PR DESCRIPTION
### Feature - authed git clones for rule engine creation
👋 Hey team :)
I'd like to add the git auth mechanism (back) in so one can pull from private repos/orgs via basic/tokened auth.

Auth is already supported by the underlying `gitresource.go` file as can be seen [here](https://github.com/hyperjumptech/grule-rule-engine/blob/master/pkg/gitresource.go#L41),
and is supported by the `go-git` as can be seen [here](https://pkg.go.dev/gopkg.in/src-d/go-git.v4#example-PlainClone-AccessToken)


Would love to get this in if possible :)
lmk if anything extra is needed