### PR TITLE
feat: extend map func

### DIFF
--- a/model/DataAccessLayer.go
+++ b/model/DataAccessLayer.go
@@ -240,3 +240,46 @@ func ArrMapLen(arr reflect.Value, arg []reflect.Value) (reflect.Value, error) {
 	}
 	return reflect.ValueOf(arr.Len()), nil
 }
+
+// MapEqualValues will check all values are equal
+func MapEqualValues(val reflect.Value, arg []reflect.Value) (reflect.Value, error) {
+	if arg != nil && len(arg) != 0 {
+		return reflect.ValueOf(false), fmt.Errorf("function EqualValues requires no argument")
+	}
+	m, ok := val.Interface().(map[string]string)
+	if !ok || len(m) == 0 {
+		return reflect.ValueOf(false), fmt.Errorf("function EqualValues requires map[string]string")
+	}
+
+	last := ""
+	for _, v := range m {
+		if last == "" {
+			last = v
+		} else if last != v {
+			return reflect.ValueOf(false), nil
+		}
+	}
+
+	return reflect.ValueOf(true), nil
+}
+
+// MapCountValue will return number of value which is equal to arg[0]
+func MapCountValue(val reflect.Value, arg []reflect.Value) (reflect.Value, error) {
+	if arg == nil || len(arg) != 1 || arg[0].Kind() != reflect.String {
+		return reflect.ValueOf(0), fmt.Errorf("function MapCountValue requires no argument")
+	}
+	m, ok := val.Interface().(map[string]string)
+	if !ok || len(m) == 0 {
+		return reflect.ValueOf(0), fmt.Errorf("function MapCountValue requires map[string]string")
+	}
+
+	to := arg[0].String()
+	cnt := int(0)
+	for _, v := range m {
+		if v == to {
+			cnt++
+		}
+	}
+
+	return reflect.ValueOf(cnt), nil
+}

--- a/model/DataAccessLayer_test.go
+++ b/model/DataAccessLayer_test.go
@@ -209,3 +209,57 @@ func TestStrMatchRegexPattern_Not_Match(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, val.Bool())
 }
+
+func TestMapEqualValues(t *testing.T) {
+	val, err := MapEqualValues(reflect.ValueOf(map[string]string{}), []reflect.Value{})
+	assert.Error(t, err)
+	val, err = MapEqualValues(reflect.ValueOf(map[string]int64{}), []reflect.Value{})
+	assert.Error(t, err)
+	anMap := map[string]string{
+		"1": "a",
+		"2": "b",
+		"3": "c",
+	}
+	val, err = MapEqualValues(reflect.ValueOf(anMap), []reflect.Value{})
+	assert.NoError(t, err)
+	assert.True(t, val.IsValid())
+	assert.Equal(t, false, val.Bool())
+	anMap2 := map[string]string{
+		"1": "a",
+		"2": "a",
+		"3": "a",
+	}
+	val, err = MapEqualValues(reflect.ValueOf(anMap2), []reflect.Value{})
+	assert.NoError(t, err)
+	assert.True(t, val.IsValid())
+	assert.Equal(t, true, val.Bool())
+}
+
+func TestMapCountValue(t *testing.T) {
+	val, err := MapCountValue(reflect.ValueOf(map[string]string{}), []reflect.Value{})
+	assert.Error(t, err)
+	val, err = MapCountValue(reflect.ValueOf(map[string]int64{}), []reflect.Value{})
+	assert.Error(t, err)
+	anMap := map[string]string{
+		"1": "a",
+		"2": "b",
+		"3": "c",
+	}
+	val, err = MapCountValue(reflect.ValueOf(anMap), []reflect.Value{reflect.ValueOf("a")})
+	assert.NoError(t, err)
+	assert.True(t, val.IsValid())
+	assert.Equal(t, 1, int(val.Int()))
+	val, err = MapCountValue(reflect.ValueOf(anMap), []reflect.Value{reflect.ValueOf("aa")})
+	assert.NoError(t, err)
+	assert.True(t, val.IsValid())
+	assert.Equal(t, 0, int(val.Int()))
+	anMap2 := map[string]string{
+		"1": "a",
+		"2": "a",
+		"3": "a",
+	}
+	val, err = MapCountValue(reflect.ValueOf(anMap2), []reflect.Value{reflect.ValueOf("a")})
+	assert.NoError(t, err)
+	assert.True(t, val.IsValid())
+	assert.Equal(t, 3, int(val.Int()))
+}

--- a/model/GoDataAccessLayer.go
+++ b/model/GoDataAccessLayer.go
@@ -401,6 +401,10 @@ func (node *GoValueNode) CallFunction(funcName string, args ...reflect.Value) (r
 		switch funcName {
 		case "Len":
 			mapFunc = ArrMapLen
+		case "EqualValues":
+			mapFunc = MapEqualValues
+		case "CountValue":
+			mapFunc = MapCountValue
 		}
 		if mapFunc != nil {
 			val, err := mapFunc(node.thisValue, args)


### PR DESCRIPTION
extend map to support two built-in functions:
- MapEqualValues: all values are equal
- MapCountValue: count number of values which are equal to arg[0]