### PR TITLE
Catch panics during rule evaluation and return an error

### DIFF
--- a/ast/RuleEntry.go
+++ b/ast/RuleEntry.go
@@ -157,10 +157,15 @@ func (e *RuleEntry) SetGrlText(grlText string) {
 }
 
 // Evaluate will evaluate this AST graph for when scope evaluation
-func (e *RuleEntry) Evaluate(ctx context.Context, dataContext IDataContext, memory *WorkingMemory) (bool, error) {
+func (e *RuleEntry) Evaluate(ctx context.Context, dataContext IDataContext, memory *WorkingMemory) (bool, err error) {
 	if ctx.Err() != nil {
 		return false, ctx.Err()
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("Error while evaluating rule %s, panic recovered", e.RuleName)
+		}
+	}()
 	if e.Retracted {
 		return false, nil
 	}

--- a/ast/RuleEntry.go
+++ b/ast/RuleEntry.go
@@ -157,7 +157,7 @@ func (e *RuleEntry) SetGrlText(grlText string) {
 }
 
 // Evaluate will evaluate this AST graph for when scope evaluation
-func (e *RuleEntry) Evaluate(ctx context.Context, dataContext IDataContext, memory *WorkingMemory) (bool, err error) {
+func (e *RuleEntry) Evaluate(ctx context.Context, dataContext IDataContext, memory *WorkingMemory) (can bool, err error) {
 	if ctx.Err() != nil {
 		return false, ctx.Err()
 	}


### PR DESCRIPTION
Currently if "e.WhenScope.Evaluate" results in a panic (for example if a rule is written that calls a custom function with the incorrect number of arguments) then the panic is not caught.

This can result in the engine completely failing to process all document.

This changes means that a malformed rule can be simply skipped based on the status of g.ReturnErrOnFailedRuleEvaluation in Engine.go.