### PR TITLE
Closes #385: Call EvaluateRuleEntry listeners when rules evaluated in FindMatchingRules

### DIFF
--- a/engine/GruleEngine.go
+++ b/engine/GruleEngine.go
@@ -259,6 +259,8 @@ func (g *GruleEngine) FetchMatchingRules(dataCtx ast.IDataContext, knowledge *as
 			if can {
 				runnable = append(runnable, v)
 			}
+			// notify all listeners that a rule's when scope has been evaluated.
+			g.notifyEvaluateRuleEntry(0, v, can)
 		}
 	}
 	log.Debugf("Matching rules length %d.", len(runnable))


### PR DESCRIPTION
Rules can be evaluated both in the engine's ExecuteWithContext()/Execute() function and inside of FindMatchingRules(), but listeners are only triggered in the Execute() call.

It'd be helpful if notifyEvaluateRuleEntry were added to FindMatchingRules() to trigger EvaluateRuleEntry listeners when FindMatchingRules() is called.

My motivation for this is to be able to get the rule names affected when FindMatchingRules() returns an error during processing of a rule like I'd do with a listener for Evaluate().