### PR TITLE
fix: typo in docs

### DIFF
--- a/docs/en/FAQ_en.md
+++ b/docs/en/FAQ_en.md
@@ -134,9 +134,9 @@ We don't want to couple Grule to any particular database implementation.
 
 ---
 
-## 3. Maximum number of rule in one knowledge-base
+## 3. Maximum number of rules in one knowledge-base
 
-**Question**: How many rule entry can be inserted into knowledgebase?
+**Question**: How many rule entries can be inserted into knowledgebase?
 
 **Answer**: You can have as many rule entries you want but there should be at
 least one minimum.
@@ -154,7 +154,7 @@ least one minimum.
 
 ## 5. Rule Engine use-case
 
-**Question**: I have read about the rule engine, but what real benefit it can bring? Give us some use-cases.
+**Question**: I have read about the rule engine, but what real benefits can bring it? Give us some use-cases.
 
 **Answer**: The following cases are better solved with a rule-engine in my humble opinion.
 

--- a/docs/en/FAQ_en.md
+++ b/docs/en/FAQ_en.md
@@ -124,7 +124,7 @@ following the `Retract` call.  The subsequent cycle will re-introduce the call.
 **Question**: Is there a plan to integrate Grule with a database storage system?
 
 **Answer**: No. While it is a good idea to store your rule entries in some sort
-of database, Grule will not create any database adapter to automaticaly store
+of database, Grule will not create any database adapter to automatically store
 and retrieve rules.  You can easily create such adapter yourself using the
 common interfaces on the Knowledgebase: *Reader*, *File*, *Byte Array*, *String*
 and *Git*. Strings can be easily inserted and selected from database, as you

--- a/docs/en/Function_en.md
+++ b/docs/en/Function_en.md
@@ -157,7 +157,7 @@ rule CheckStartTime "Check device's starting time." {
 
 `Retract` will exclude the specified rule from the subsequent cycle evaluations. If a
 rule is retracted its `when` scope will not be evaluated on the next cycles after the call to `Retract`. 
-The engine will automatically resets all rule back inplace when it start again from the beginning.
+The engine will automatically resets all rule back inplace when it starts again from the beginning.
 
 #### Arguments
 

--- a/docs/en/GRL_JSON_en.md
+++ b/docs/en/GRL_JSON_en.md
@@ -88,7 +88,7 @@ The following operators have slightly different behaviours than the standard ope
 | `"set"`   | GRL = operator. This operator will set the value of the first operand to the output of the second. This can only be used in the `then` section of the rule.                                                                |
 | `"call"`  | GRL function call. The operator will call the funtion name specified in the first operand. If more then one operand is specififed, the subsequent operands are interpreted as arguments to be passed to the funciton call. |
 | `"obj"`   | Explicitly identifies a GRL object. Unlike other operators, this object takes the form of a simple key/value pair. For example: `{"obj": "TestCar.Speed"}`                                                                 |
-| `"const"` | Explicitly identifies a GRL constant. This opertor takes the same form as the `obj` operator                                                                                                                               |
+| `"const"` | Explicitly identifies a GRL constant. This operator takes the same form as the `obj` operator                                                                                                                               |
 
 ### Supported Constants
 

--- a/docs/en/GRL_JSON_en.md
+++ b/docs/en/GRL_JSON_en.md
@@ -39,7 +39,7 @@ The basic structure of a JSON rule is as follows:
 
 ## Condition Object
 
-In order to provide a great deal of flexability, the `when` condition of a rule
+In order to provide a great deal of flexibility, the `when` condition of a rule
 can be broken down into individual components. This is particularly useful for
 structuring larger rules and supporting GUI applications used for rule editing
 and analysis.


### PR DESCRIPTION
small typo fix in the docs