### PR TITLE
Updating RuleEntry.Evaluate error logging to include value returned by recover.

### DIFF
--- a/ast/RuleEntry.go
+++ b/ast/RuleEntry.go
@@ -171,7 +171,7 @@ func (e *RuleEntry) Evaluate(ctx context.Context, dataContext IDataContext, memo
 	}
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("error while evaluating rule %s, panic recovered", e.RuleName)
+			err = fmt.Errorf("error while evaluating rule %s ! recovered : %v", e.RuleName, r)
 			can = false
 		}
 	}()


### PR DESCRIPTION
In order to make troubleshooting of rule entries that panic during evaluation easier, I have update the error message to include the value returned by recover.  This logging of `r` is being done in the `Execute` method on [line 208](https://github.com/hyperjumptech/grule-rule-engine/blob/master/ast/RuleEntry.go#L208) so I used this line as an example and followed the same format.