### PR TITLE
get rid of unneeded memory allocations when using string builders instead of byte buffers

### DIFF
--- a/ast/ArgumentList.go
+++ b/ast/ArgumentList.go
@@ -15,9 +15,9 @@
 package ast
 
 import (
-	"bytes"
 	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"reflect"
+	"strings"
 
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
 )
@@ -103,7 +103,7 @@ func (e *ArgumentList) GetGrlText() string {
 
 // GetSnapshot will create a structure signature or AST graph
 func (e *ArgumentList) GetSnapshot() string {
-	var buff bytes.Buffer
+	var buff strings.Builder
 	buff.WriteString(ARGUMENTLIST)
 	buff.WriteString("(")
 	for i, v := range e.Arguments {

--- a/ast/ArrayMapSelector.go
+++ b/ast/ArrayMapSelector.go
@@ -15,11 +15,11 @@
 package ast
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
 	"reflect"
+	"strings"
 )
 
 // NewArrayMapSelector create a new array selector graph
@@ -106,7 +106,7 @@ func (e *ArrayMapSelector) GetGrlText() string {
 
 // GetSnapshot will create a structure signature or AST graph
 func (e *ArrayMapSelector) GetSnapshot() string {
-	var buff bytes.Buffer
+	var buff strings.Builder
 	buff.WriteString(MAPARRAYSELECTOR)
 	buff.WriteString("(")
 	if e.Expression != nil {

--- a/ast/Assignment.go
+++ b/ast/Assignment.go
@@ -15,10 +15,10 @@
 package ast
 
 import (
-	"bytes"
 	"errors"
 	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
+	"strings"
 )
 
 // NewAssignment will create new instance of Assignment AST Node
@@ -141,7 +141,7 @@ func (e *Assignment) GetGrlText() string {
 
 // GetSnapshot will create a structure signature or AST graph
 func (e *Assignment) GetSnapshot() string {
-	var buff bytes.Buffer
+	var buff strings.Builder
 	buff.WriteString(ASSIGMENT)
 	buff.WriteString("(")
 	buff.WriteString(e.Variable.GetSnapshot())

--- a/ast/Constant.go
+++ b/ast/Constant.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"math"
 	"reflect"
+	"strings"
 
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
 )
@@ -116,7 +117,7 @@ func (e *Constant) GetGrlText() string {
 
 // GetSnapshot will create a structure signature or AST graph
 func (e *Constant) GetSnapshot() string {
-	var buff bytes.Buffer
+	var buff strings.Builder
 	buff.WriteString(CONSTANT)
 	buff.WriteString("(")
 	buff.WriteString(e.Value.Kind().String())

--- a/ast/Expression.go
+++ b/ast/Expression.go
@@ -15,11 +15,11 @@
 package ast
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"reflect"
+	"strings"
 
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
 )
@@ -208,7 +208,7 @@ func (e *Expression) GetGrlText() string {
 
 // GetSnapshot will create a structure signature or AST graph
 func (e *Expression) GetSnapshot() string {
-	var buff bytes.Buffer
+	var buff strings.Builder
 	buff.WriteString(EXPRESSION)
 	buff.WriteString("(")
 	if e.SingleExpression != nil {

--- a/ast/ExpressionAtom.go
+++ b/ast/ExpressionAtom.go
@@ -15,12 +15,12 @@
 package ast
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"github.com/hyperjumptech/grule-rule-engine/model"
 	"reflect"
+	"strings"
 
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
 )
@@ -224,7 +224,7 @@ func (e *ExpressionAtom) GetGrlText() string {
 
 // GetSnapshot will create a structure signature or AST graph
 func (e *ExpressionAtom) GetSnapshot() string {
-	var buff bytes.Buffer
+	var buff strings.Builder
 	buff.WriteString(EXPRESSIONATOM)
 	buff.WriteString("(")
 	if e.Variable != nil {

--- a/ast/FunctionCall.go
+++ b/ast/FunctionCall.go
@@ -15,11 +15,11 @@
 package ast
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
 	"reflect"
+	"strings"
 )
 
 // NewFunctionCall creates new instance of FunctionCall
@@ -99,7 +99,7 @@ func (e *FunctionCall) GetGrlText() string {
 
 // GetSnapshot will create a structure signature or AST graph
 func (e *FunctionCall) GetSnapshot() string {
-	var buff bytes.Buffer
+	var buff strings.Builder
 	buff.WriteString(FUNCTIONCALL)
 	buff.WriteString(fmt.Sprintf("(n:%s", e.FunctionName))
 	if e.ArgumentList != nil {

--- a/ast/KnowledgeBase.go
+++ b/ast/KnowledgeBase.go
@@ -15,7 +15,6 @@
 package ast
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"sort"
@@ -98,12 +97,12 @@ func (lib *KnowledgeLibrary) LoadKnowledgeBaseFromReader(reader io.Reader, overw
 		return nil, err
 	}
 	if overwrite {
-		lib.Library[GetKnowledgeBaseKey(knowledgeBase.Name,knowledgeBase.Version)] = knowledgeBase
+		lib.Library[GetKnowledgeBaseKey(knowledgeBase.Name, knowledgeBase.Version)] = knowledgeBase
 
 		return knowledgeBase, nil
 	}
-	if _, ok := lib.Library[GetKnowledgeBaseKey(knowledgeBase.Name,knowledgeBase.Version)]; !ok {
-		lib.Library[GetKnowledgeBaseKey(knowledgeBase.Name,knowledgeBase.Version)] = knowledgeBase
+	if _, ok := lib.Library[GetKnowledgeBaseKey(knowledgeBase.Name, knowledgeBase.Version)]; !ok {
+		lib.Library[GetKnowledgeBaseKey(knowledgeBase.Name, knowledgeBase.Version)] = knowledgeBase
 
 		return knowledgeBase, nil
 	}
@@ -194,7 +193,7 @@ func (e *KnowledgeBase) IsIdentical(that *KnowledgeBase) bool {
 
 // GetSnapshot will create this knowledge base signature
 func (e *KnowledgeBase) GetSnapshot() string {
-	var buffer bytes.Buffer
+	var buffer strings.Builder
 	buffer.WriteString(fmt.Sprintf("%s:%s[", e.Name, e.Version))
 	keys := make([]string, 0)
 	for i := range e.RuleEntries {

--- a/ast/RuleEntry.go
+++ b/ast/RuleEntry.go
@@ -15,11 +15,11 @@
 package ast
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"reflect"
+	"strings"
 
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
 )
@@ -148,7 +148,7 @@ func (e *RuleEntry) GetGrlText() string {
 
 // GetSnapshot will create a structure signature or AST graph
 func (e *RuleEntry) GetSnapshot() string {
-	var buff bytes.Buffer
+	var buff strings.Builder
 	buff.WriteString(RULEENTRY)
 	buff.WriteString("(")
 	buff.WriteString(fmt.Sprintf("N:%s DEC:\"%s\" SAL:%d W:%s T:%s}", e.RuleName, e.RuleDescription, e.Salience, e.WhenScope.GetSnapshot(), e.ThenScope.GetSnapshot()))

--- a/ast/ThenExpression.go
+++ b/ast/ThenExpression.go
@@ -15,9 +15,9 @@
 package ast
 
 import (
-	"bytes"
 	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
+	"strings"
 )
 
 // NewThenExpression create new instance of ThenExpression
@@ -121,7 +121,7 @@ func (e *ThenExpression) GetGrlText() string {
 
 // GetSnapshot will create a structure signature or AST graph
 func (e *ThenExpression) GetSnapshot() string {
-	var buff bytes.Buffer
+	var buff strings.Builder
 	buff.WriteString(THENEXPRESSION)
 	buff.WriteString("(")
 	if e.Assignment != nil {

--- a/ast/ThenExpressionList.go
+++ b/ast/ThenExpressionList.go
@@ -15,9 +15,9 @@
 package ast
 
 import (
-	"bytes"
 	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
+	"strings"
 )
 
 // NewThenExpressionList creates new instance of ThenExpressionList
@@ -109,7 +109,7 @@ func (e *ThenExpressionList) GetGrlText() string {
 
 // GetSnapshot will create a structure signature or AST graph
 func (e *ThenExpressionList) GetSnapshot() string {
-	var buff bytes.Buffer
+	var buff strings.Builder
 	buff.WriteString(THENEXPRESSIONLIST)
 	buff.WriteString("(")
 	if e.ThenExpressions != nil {

--- a/ast/ThenScope.go
+++ b/ast/ThenScope.go
@@ -15,9 +15,9 @@
 package ast
 
 import (
-	"bytes"
 	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
+	"strings"
 )
 
 // NewThenScope will create new instance of ThenScope
@@ -99,7 +99,7 @@ func (e *ThenScope) GetGrlText() string {
 
 // GetSnapshot will create a structure signature or AST graph
 func (e *ThenScope) GetSnapshot() string {
-	var buff bytes.Buffer
+	var buff strings.Builder
 	buff.WriteString(THENSCOPE)
 	buff.WriteString("(")
 	if e.ThenExpressionList != nil {

--- a/ast/Variable.go
+++ b/ast/Variable.go
@@ -15,11 +15,11 @@
 package ast
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"github.com/hyperjumptech/grule-rule-engine/model"
 	"reflect"
+	"strings"
 
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
 )
@@ -140,7 +140,7 @@ func (e *Variable) GetGrlText() string {
 
 // GetSnapshot will create a structure signature or AST graph
 func (e *Variable) GetSnapshot() string {
-	var buff bytes.Buffer
+	var buff strings.Builder
 	buff.WriteString(VARIABLE)
 	buff.WriteString("(")
 	if len(e.Name) > 0 && e.Variable == nil {

--- a/ast/WhenScope.go
+++ b/ast/WhenScope.go
@@ -15,10 +15,10 @@
 package ast
 
 import (
-	"bytes"
 	"errors"
 	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"reflect"
+	"strings"
 
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
 )
@@ -106,7 +106,7 @@ func (e *WhenScope) GetGrlText() string {
 
 // GetSnapshot will create a structure signature or AST graph
 func (e *WhenScope) GetSnapshot() string {
-	var buff bytes.Buffer
+	var buff strings.Builder
 	buff.WriteString(WHENSCOPE)
 	buff.WriteString("(")
 	if e.Expression != nil {


### PR DESCRIPTION
get rid of unneeded memory allocations when using string builders instead of byte buffers 
as advised on #485 