### PR TITLE
Fix: Prevent nil pointer dereference when reporting rule evaluation errors

### DIFF
--- a/ast/RuleEntry.go
+++ b/ast/RuleEntry.go
@@ -17,9 +17,10 @@ package ast
 import (
 	"context"
 	"fmt"
-	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"reflect"
 	"strings"
+
+	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
 )
@@ -183,11 +184,11 @@ func (e *RuleEntry) Evaluate(ctx context.Context, dataContext IDataContext, memo
 	if err != nil {
 		AstLog.Errorf("Error while evaluating rule %s, got %v", e.RuleName, err)
 
-		return false, fmt.Errorf("evaluating expression in rule '%s' the when raised an error. got %v", dataContext.GetRuleEntry().RuleName, err)
+		return false, fmt.Errorf("evaluating expression in rule '%s' the when raised an error. got %v", e.RuleName, err)
 	}
 	if val.Kind() != reflect.Bool {
 
-		return false, fmt.Errorf("evaluating expression in rule '%s', the when is not a boolean expression : %s", dataContext.GetRuleEntry().RuleName, e.WhenScope.Expression.GetGrlText())
+		return false, fmt.Errorf("evaluating expression in rule '%s', the when is not a boolean expression : %s", e.RuleName, e.WhenScope.Expression.GetGrlText())
 	}
 
 	return val.Bool(), nil


### PR DESCRIPTION
## Problem

When a rule contains an invalid function/field(s) in its [when] expression, the engine logs the error but then panics with a nil pointer dereference.
This happens because the error reporting `(Line 186)` :

```
fmt.Errorf("evaluating expression in rule '%s' the when raised an error. got %v", dataContext.GetRuleEntry().RuleName, err)
```

tries to access `dataContext.GetRuleEntry().RuleName` before [SetRuleEntry](https://github.com/rohitss912/grule-rule-engine/blob/4bfa44221ed3e65e686b8c882a88aabd2bcf625a/engine/GruleEngine.go#L234-L235) is called in `engine.go`, resulting in a nil pointer dereference.

## How to Reproduce
Use a rule with an invalid function in the [when] clause, for example:
```
rule BadRule "Rule with invalid function" {
    when
        MyApp.IsProduction == false && MyApp.PlatformType.IsIn("DataCenterEU")
    then
        // some action
}
```
Here, `IsIn`  is not a valid function for a string in Grule.

### Observed Behavior
The AST logger prints the actual error [`(Line 184)`:](https://github.com/rohitss912/grule-rule-engine/blob/master/ast/RuleEntry.go#L185-L186)

```
caller":"ast/RuleEntry.go:184","message":"Error while evaluating rule BadRule, got right hand expression error.  got this node identified as \"MyApp.PlatformType\" call function IsIn is not supported for string"
```

But instead of returning this error to the caller, the engine panics and returns the below error message which could be misleading to the caller of the rule-engine :

```
 Got error error while evaluating rule BadRule ! recovered : runtime error: invalid memory address or nil pointer dereference
```

## Solution

Change the error reporting to use the current RuleEntry's `e.RuleName` directly, rather than accessing it via `dataContext.GetRuleEntry()`, as the code anyway uses `e.RuleName` to prepare the AST logger error message.

This ensures error messages are constructed safely, even if the rule's name has not yet been set in the data context.

### Code Fix

Before:

```
return false, fmt.Errorf("evaluating expression in rule '%s' the when raised an error. got %v", dataContext.GetRuleEntry().RuleName, err)
```

After:

```
return false, fmt.Errorf("evaluating expression in rule '%s' the when raised an error. got %v", e.RuleName, err)
```

### Impact
Prevents engine panics when evaluating rules with invalid syntax.
Ensures errors are returned to the caller as expected.
No impact on valid rule execution or rule selection logic