### PR TITLE
Feat: allow general nil value ignore

### DIFF
--- a/ast/ExpressionAtom.go
+++ b/ast/ExpressionAtom.go
@@ -366,6 +366,9 @@ func (e *ExpressionAtom) Evaluate(dataContext IDataContext, memory *WorkingMemor
 
 		retVal, err := e.ExpressionAtom.ValueNode.CallFunction(e.FunctionCall.FunctionName, args...)
 		if err != nil {
+			if e.CompareNilValues {
+				return reflect.ValueOf(nil), nil
+			}
 
 			return reflect.ValueOf(nil), err
 		}

--- a/ast/ExpressionAtom.go
+++ b/ast/ExpressionAtom.go
@@ -360,6 +360,10 @@ func (e *ExpressionAtom) Evaluate(dataContext IDataContext, memory *WorkingMemor
 			return reflect.ValueOf(nil), err
 		}
 
+		if e.ExpressionAtom.ValueNode == nil && e.CompareNilValues {
+			return reflect.ValueOf(nil), nil
+		}
+
 		retVal, err := e.ExpressionAtom.ValueNode.CallFunction(e.FunctionCall.FunctionName, args...)
 		if err != nil {
 

--- a/ast/ExpressionAtom.go
+++ b/ast/ExpressionAtom.go
@@ -17,10 +17,11 @@ package ast
 import (
 	"errors"
 	"fmt"
-	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
-	"github.com/hyperjumptech/grule-rule-engine/model"
 	"reflect"
 	"strings"
+
+	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
+	"github.com/hyperjumptech/grule-rule-engine/model"
 
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
 )
@@ -49,7 +50,8 @@ type ExpressionAtom struct {
 	Value     reflect.Value
 	ValueNode model.ValueNode
 
-	Evaluated bool
+	Evaluated        bool
+	CompareNilValues bool
 }
 
 // MakeCatalog will create a catalog entry from ExpressionAtom node.
@@ -265,10 +267,22 @@ func (e *ExpressionAtom) SetGrlText(grlText string) {
 
 // Evaluate will evaluate this AST graph for when scope evaluation
 func (e *ExpressionAtom) Evaluate(dataContext IDataContext, memory *WorkingMemory) (val reflect.Value, err error) {
-	if e.Evaluated == true {
+	// Extract COMPARE_NILS from dataContext as a bool, defaulting to false when unavailable or not boolean.
+	compareNode := dataContext.Get("COMPARE_NILS")
+	if compareNode != nil {
+		if rv := compareNode.Value(); rv.IsValid() && rv.Kind() == reflect.Bool {
+			e.CompareNilValues = rv.Bool()
+		} else {
+			e.CompareNilValues = false
+		}
+	} else {
+		e.CompareNilValues = false
+	}
 
+	if e.Evaluated {
 		return e.Value, nil
 	}
+
 	if e.Constant != nil {
 		val, err := e.Constant.Evaluate(dataContext, memory)
 		if err != nil {
@@ -368,6 +382,13 @@ func (e *ExpressionAtom) Evaluate(dataContext IDataContext, memory *WorkingMemor
 		}
 		valueNode, err := e.ExpressionAtom.ValueNode.GetChildNodeByField(e.VariableName)
 		if err != nil {
+			if e.CompareNilValues {
+				e.ValueNode = model.NewGoValueNode(reflect.ValueOf(nil), fmt.Sprintf("%s.%s->nil", e.ExpressionAtom.ValueNode.IdentifiedAs(), e.VariableName))
+				e.Value = e.ValueNode.Value()
+				e.Evaluated = true
+
+				return e.Value, nil
+			}
 
 			return reflect.Value{}, err
 		}

--- a/engine/GruleEngine.go
+++ b/engine/GruleEngine.go
@@ -17,11 +17,12 @@ package engine
 import (
 	"context"
 	"fmt"
+	"sort"
+	"time"
+
 	"github.com/rs/zerolog"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
-	"sort"
-	"time"
 
 	"github.com/hyperjumptech/grule-rule-engine/ast"
 	"github.com/hyperjumptech/grule-rule-engine/logger"
@@ -87,6 +88,7 @@ func NewGruleEngine() *GruleEngine {
 type GruleEngine struct {
 	MaxCycle                        uint64
 	ReturnErrOnFailedRuleEvaluation bool
+	CompareNilValues                bool
 	Listeners                       []GruleEngineListener
 }
 
@@ -146,6 +148,13 @@ func (g *GruleEngine) ExecuteWithContext(ctx context.Context, dataCtx ast.IDataC
 	err := dataCtx.Add("DEFUNC", defunc)
 	if err != nil {
 		log.Error("DEFUNC add err")
+
+		return err
+	}
+
+	err = dataCtx.Add("COMPARE_NILS", g.CompareNilValues)
+	if err != nil {
+		log.Error("COMPARE_NILS add err")
 
 		return err
 	}
@@ -279,6 +288,12 @@ func (g *GruleEngine) FetchMatchingRules(dataCtx ast.IDataContext, knowledge *as
 		return nil, err
 	}
 
+	err = dataCtx.Add("COMPARE_NILS", g.CompareNilValues)
+	if err != nil {
+		log.Error("COMPARE_NILS add err")
+
+		return nil, err
+	}
 	// Working memory need to be resetted. all Expression will be set as not evaluated.
 	log.Debugf("Resetting Working memory")
 	knowledge.WorkingMemory.ResetAll()

--- a/engine/GruleEngine_test.go
+++ b/engine/GruleEngine_test.go
@@ -140,9 +140,10 @@ func getTypeOf(i interface{}) string {
 	return t.Name()
 }
 
+// TODO: Add also tests when function argument(s) are nil pointers
 const ruleWithAccessErr = `rule AccessErrRule "test access error rule" salience 10 {
     when
-        TestStruct.NotExist == 1 || TestStruct.OtherNonExists || TestStruct.ThirdNonExist.StrContains("included value") == true
+        TestStruct.NotExist == 1 || TestStruct.OtherNonExists || TestStruct.ThirdNonExist.Contains("included value") == true || TestStruct.exist.Contains(TestStruct.NonExisting) == true
     then
 		Retract("AccessErrRule");
 }`
@@ -167,7 +168,8 @@ func TestEngine_ExecuteErr(t *testing.T) {
 
 func TestEngine_ExecuteHandleNilsJSON(t *testing.T) {
 	dctx := ast.NewDataContext()
-	err := dctx.AddJSON("TestStruct", []byte("{}"))
+	testJson := `{ "exist": "\"This field exist\"" }`
+	err := dctx.AddJSON("TestStruct", []byte(testJson))
 	assert.NoError(t, err)
 
 	lib := ast.NewKnowledgeLibrary()

--- a/engine/GruleEngine_test.go
+++ b/engine/GruleEngine_test.go
@@ -142,7 +142,7 @@ func getTypeOf(i interface{}) string {
 
 const ruleWithAccessErr = `rule AccessErrRule "test access error rule" salience 10 {
     when
-        TestStruct.NotExist == 1
+        TestStruct.NotExist == 1 || TestStruct.OtherNonExists
     then
 		Retract("AccessErrRule");
 }`
@@ -154,7 +154,7 @@ func TestEngine_ExecuteErr(t *testing.T) {
 
 	lib := ast.NewKnowledgeLibrary()
 	rb := builder.NewRuleBuilder(lib)
-	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(rules)))
+	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(ruleWithAccessErr)))
 	assert.NoError(t, err)
 
 	engine := NewGruleEngine()
@@ -163,6 +163,25 @@ func TestEngine_ExecuteErr(t *testing.T) {
 	assert.NoError(t, err)
 	err = engine.Execute(dctx, kb)
 	assert.Error(t, err)
+}
+
+func TestEngine_ExecuteHandleNils(t *testing.T) {
+	dctx := ast.NewDataContext()
+	err := dctx.Add("TestStruct", &TestStruct{})
+	assert.NoError(t, err)
+
+	lib := ast.NewKnowledgeLibrary()
+	rb := builder.NewRuleBuilder(lib)
+	err = rb.BuildRuleFromResource("Test", "0.1.1", pkg.NewBytesResource([]byte(ruleWithAccessErr)))
+	assert.NoError(t, err)
+
+	engine := NewGruleEngine()
+	engine.ReturnErrOnFailedRuleEvaluation = true
+	engine.CompareNilValues = true
+	kb, err := lib.NewKnowledgeBaseInstance("Test", "0.1.1")
+	assert.NoError(t, err)
+	err = engine.Execute(dctx, kb)
+	assert.NoError(t, err)
 }
 
 func TestEmptyValueEquality(t *testing.T) {


### PR DESCRIPTION
- allows engine to handle nil values in rules
    - useful e.g. with JSON facts that are not having strict schema
- Fixes #458 
- Fixes #429 