### PR TITLE
fix: error wrap instead of including as string

### DIFF
--- a/ast/Expression.go
+++ b/ast/Expression.go
@@ -17,10 +17,10 @@ package ast
 import (
 	"errors"
 	"fmt"
-	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"reflect"
 	"strings"
 
+	"github.com/hyperjumptech/grule-rule-engine/ast/unique"
 	"github.com/hyperjumptech/grule-rule-engine/pkg"
 )
 
@@ -316,7 +316,7 @@ func (e *Expression) Evaluate(dataContext IDataContext, memory *WorkingMemory) (
 		if e.Operator == OpAnd {
 			if lerr != nil {
 
-				return reflect.Value{}, fmt.Errorf("left hand expression error. got %v", lerr)
+				return reflect.Value{}, fmt.Errorf("left hand expression error. got %w", lerr)
 			}
 			val, opErr = pkg.EvaluateLogicSingle(lval)
 			if opErr == nil && !val.Bool() {
@@ -329,7 +329,7 @@ func (e *Expression) Evaluate(dataContext IDataContext, memory *WorkingMemory) (
 		if e.Operator == OpOr {
 			if lerr != nil {
 
-				return reflect.Value{}, fmt.Errorf("left hand expression error. got %v", lerr)
+				return reflect.Value{}, fmt.Errorf("left hand expression error. got %w", lerr)
 			}
 			val, opErr = pkg.EvaluateLogicSingle(lval)
 			if opErr == nil && val.Bool() {
@@ -343,11 +343,11 @@ func (e *Expression) Evaluate(dataContext IDataContext, memory *WorkingMemory) (
 		rval, rerr := e.RightExpression.Evaluate(dataContext, memory)
 		if lerr != nil {
 
-			return reflect.Value{}, fmt.Errorf("left hand expression error. got %v", lerr)
+			return reflect.Value{}, fmt.Errorf("left hand expression error. got %w", lerr)
 		}
 		if rerr != nil {
 
-			return reflect.Value{}, fmt.Errorf("right hand expression error.  got %v", rerr)
+			return reflect.Value{}, fmt.Errorf("right hand expression error. got %w", rerr)
 		}
 
 		switch e.Operator {

--- a/ast/RuleEntry.go
+++ b/ast/RuleEntry.go
@@ -167,7 +167,6 @@ func (e *RuleEntry) SetGrlText(grlText string) {
 // Evaluate will evaluate this AST graph for when scope evaluation
 func (e *RuleEntry) Evaluate(ctx context.Context, dataContext IDataContext, memory *WorkingMemory) (can bool, err error) {
 	if ctx.Err() != nil {
-
 		return false, fmt.Errorf("context error on evaluating rule %s. got %w", e.RuleName, ctx.Err())
 	}
 	defer func() {
@@ -184,7 +183,7 @@ func (e *RuleEntry) Evaluate(ctx context.Context, dataContext IDataContext, memo
 	if err != nil {
 		AstLog.Errorf("Error while evaluating rule %s, got %v", e.RuleName, err)
 
-		return false, fmt.Errorf("evaluating expression in rule '%s' the when raised an error. got %v", e.RuleName, err)
+		return false, fmt.Errorf("evaluating expression in rule '%s' the when raised an error. got %w", e.RuleName, err)
 	}
 	if val.Kind() != reflect.Bool {
 


### PR DESCRIPTION
- Error wrapping with `%w` introduced in Go 1.13, allows to add context to errors while preserving the original error for inspection via errors.Is or errors.As.
- Grule was previously building errors including original error with `%v` making it impossible to check for specific error types upstream.